### PR TITLE
Add discriminator validation for inner instructions

### DIFF
--- a/src/streaming/event_parser/core/traits.rs
+++ b/src/streaming/event_parser/core/traits.rs
@@ -1026,6 +1026,18 @@ impl EventParser for GenericEventParser {
         if !SimdUtils::validate_instruction_data_simd(&inner_instruction.data, 16, 0) {
             return Vec::new();
         }
+        
+        // Check if the discriminator matches what we expect for this event type
+        let discriminator_len = config.inner_instruction_discriminator.len();
+        if inner_instruction.data.len() < discriminator_len {
+            return Vec::new();
+        }
+        
+        // Validate discriminator matches
+        if !inner_instruction.data[..discriminator_len].eq(config.inner_instruction_discriminator) {
+            return Vec::new();
+        }
+        
         let data = &inner_instruction.data[16..];
         let mut events = Vec::new();
         if let Some(event) = self.parse_inner_instruction_event(
@@ -1062,6 +1074,18 @@ impl EventParser for GenericEventParser {
         if !SimdUtils::validate_instruction_data_simd(&inner_instruction.data, 16, 0) {
             return Vec::new();
         }
+        
+        // Check if the discriminator matches what we expect for this event type
+        let discriminator_len = config.inner_instruction_discriminator.len();
+        if inner_instruction.data.len() < discriminator_len {
+            return Vec::new();
+        }
+        
+        // Validate discriminator matches
+        if !inner_instruction.data[..discriminator_len].eq(config.inner_instruction_discriminator) {
+            return Vec::new();
+        }
+        
         let data = &inner_instruction.data[16..];
         let mut events = Vec::new();
         if let Some(event) = self.parse_inner_instruction_event(


### PR DESCRIPTION
Validate that inner instruction discriminators match the expected values from config before attempting to parse event data. This prevents incorrect event parsing when processing PumpFun migration events and other inner instructions with mismatched discriminators.


Transaction: `2P6VfM9JEqWaRpbWfZ4dL3HdEvGSj1i5LJfmhU55MYCpnVCqscSQiKmzhmZrXLTUYZE19BbWMwcBucb8NvvCLqfZ`


```
// Before:
PumpFunMigrateEvent { metadata: EventMetadata { signature: 2P6VfM9JEqWaRpbWfZ4dL3HdEvGSj1i5LJfmhU55MYCpnVCqscSQiKmzhmZrXLTUYZE19BbWMwcBucb8NvvCLqfZ, slot: 364468398, transaction_index: None, block_time: 1756936108, block_time_ms: 1756936108000, recv_us: 1757390513220836, handle_us: 319, protocol: PumpFun, event_type: PumpFunMigrate, program_id: 6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P, swap_data: None, outer_index: 2, inner_index: None }, user: CdDcDfPzghxvUmmYhHruxPqzbXdiTBcnRQgM9tUGnTgm, mint: 3f7dqJDsPmNhH4EWtHpGHaft7fsyKDqWqAAdafEuiuGW, mint_amount: 9447348194208759209, sol_amount: 12393439468798271403, pool_migration_fee: 1749194904153326721, bonding_curve: DwJucsAHzyXppjoZvj9jwi5YrxsqnK5dTjPdG3HPPKo6, timestamp: -6268720410229997549, pool: 41dCzs8dSxaZuKkFjeN2C8DZTN33aMcraN77GP8D71QL, global: 4wTV1YmiEkRvAtNtsSGPtUrqRYQMe5SKy2uB4Jjaxnjf, withdraw_authority: 39azUYFWPz3VHgKCf3VChUwbpURdCHRxjWVowf5jUJjg, associated_bonding_curve: 9rVQegz94AJGvwrffdWk9fnmi3VfiyzHZmas7WVrQy7r, system_program: 11111111111111111111111111111111, token_program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA, pump_amm: pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA, pool_authority: BS4awGUAE3RNCopVF3BcRVumvHvGqeuRGNQTiQZhLbK8, pool_authority_mint_account: FDYDtMjsiFVzxHyuk86pU7mM71NoVDmDDVR9gTpHT1kK, pool_authority_wsol_account: DVdzugbUL58fxKajavcYAM2i3ihr841ze6MDpM2L64wm, amm_global_config: ADyA8hdefvWN2dbGGWFotbzWxrAvLW83WG6QCVXvJKqw, wsol_mint: So11111111111111111111111111111111111111112, lp_mint: 98136qthDQogQ3wT6xxU41YUyjJDPQEEcLXeAHcUfDGN, user_pool_token_account: 5LdNBh1hz4cJNz6ExGrC9xSGE6rhDFAJ5yxwrSUuKm3E, pool_base_token_account: rBCM7hDGMby83uaYqWJgf6W2aVRhQcw3nbh7PTVo3qU, pool_quote_token_account: 553TGMAUGp4tmMA2grciypsrGZMXbd9rtANi4zo1HrDT, token_2022_program: TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb, associated_token_program: ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL, pump_amm_event_authority: GS4CU59F31iL7aR2Q8zVS8DRrcRnXX1yjQ66TqNVQnaR, event_authority: Ce6TQqeHC9p8KetsN6JsjHK7UTZk7nasjjnr7XxXp9F1, program: 6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P }

// After:
PumpFunMigrateEvent { metadata: EventMetadata { signature: 2P6VfM9JEqWaRpbWfZ4dL3HdEvGSj1i5LJfmhU55MYCpnVCqscSQiKmzhmZrXLTUYZE19BbWMwcBucb8NvvCLqfZ, slot: 364468398, transaction_index: None, block_time: 1756936108, block_time_ms: 1756936108000, recv_us: 1757390598179504, handle_us: 454, protocol: PumpFun, event_type: PumpFunMigrate, program_id: 6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P, swap_data: None, outer_index: 2, inner_index: None }, user: BnnNJJgy9w2MLQ9XBKJKG9FQa2r9qdW7u5VpzEkwUcc3, mint: 65zhLXSxBL87Q4bDuLKjo5KnaALNTQe2Pi5FznJCpump, mint_amount: 206900000000000, sol_amount: 84990359583, pool_migration_fee: 15000001, bonding_curve: HDBeHphbYS1j5KYXaEpe9tKSYkQh4yHV4gvWEWp99Xe6, timestamp: 1756936108, pool: GJReBf9GDfy1GNScKJZe98MHSWNtpmMd86KYzxvP68UK, global: 4wTV1YmiEkRvAtNtsSGPtUrqRYQMe5SKy2uB4Jjaxnjf, withdraw_authority: 39azUYFWPz3VHgKCf3VChUwbpURdCHRxjWVowf5jUJjg, associated_bonding_curve: 9rVQegz94AJGvwrffdWk9fnmi3VfiyzHZmas7WVrQy7r, system_program: 11111111111111111111111111111111, token_program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA, pump_amm: pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA, pool_authority: BS4awGUAE3RNCopVF3BcRVumvHvGqeuRGNQTiQZhLbK8, pool_authority_mint_account: FDYDtMjsiFVzxHyuk86pU7mM71NoVDmDDVR9gTpHT1kK, pool_authority_wsol_account: DVdzugbUL58fxKajavcYAM2i3ihr841ze6MDpM2L64wm, amm_global_config: ADyA8hdefvWN2dbGGWFotbzWxrAvLW83WG6QCVXvJKqw, wsol_mint: So11111111111111111111111111111111111111112, lp_mint: 98136qthDQogQ3wT6xxU41YUyjJDPQEEcLXeAHcUfDGN, user_pool_token_account: 5LdNBh1hz4cJNz6ExGrC9xSGE6rhDFAJ5yxwrSUuKm3E, pool_base_token_account: rBCM7hDGMby83uaYqWJgf6W2aVRhQcw3nbh7PTVo3qU, pool_quote_token_account: 553TGMAUGp4tmMA2grciypsrGZMXbd9rtANi4zo1HrDT, token_2022_program: TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb, associated_token_program: ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL, pump_amm_event_authority: GS4CU59F31iL7aR2Q8zVS8DRrcRnXX1yjQ66TqNVQnaR, event_authority: Ce6TQqeHC9p8KetsN6JsjHK7UTZk7nasjjnr7XxXp9F1, program: 6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P }

// Other events:
PumpSwapCreatePoolEvent { metadata: EventMetadata { signature: 2P6VfM9JEqWaRpbWfZ4dL3HdEvGSj1i5LJfmhU55MYCpnVCqscSQiKmzhmZrXLTUYZE19BbWMwcBucb8NvvCLqfZ, slot: 364468398, transaction_index: None, block_time: 1756936108, block_time_ms: 1756936108000, recv_us: 1757390598179504, handle_us: 1145, protocol: PumpSwap, event_type: PumpSwapCreatePool, program_id: pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA, swap_data: None, outer_index: 2, inner_index: Some(22) }, timestamp: 1756936108, index: 0, creator: BS4awGUAE3RNCopVF3BcRVumvHvGqeuRGNQTiQZhLbK8, base_mint: 65zhLXSxBL87Q4bDuLKjo5KnaALNTQe2Pi5FznJCpump, quote_mint: So11111111111111111111111111111111111111112, base_mint_decimals: 6, quote_mint_decimals: 9, base_amount_in: 206900000000000, quote_amount_in: 84990359583, pool_base_amount: 206900000000000, pool_quote_amount: 84990359583, minimum_liquidity: 100, initial_liquidity: 4193388295605, lp_token_amount_out: 4193388295505, pool_bump: 255, pool: GJReBf9GDfy1GNScKJZe98MHSWNtpmMd86KYzxvP68UK, lp_mint: 98136qthDQogQ3wT6xxU41YUyjJDPQEEcLXeAHcUfDGN, user_base_token_account: FDYDtMjsiFVzxHyuk86pU7mM71NoVDmDDVR9gTpHT1kK, user_quote_token_account: DVdzugbUL58fxKajavcYAM2i3ihr841ze6MDpM2L64wm, coin_creator: DZExCWF6ySE6QSaKyZgcRctbrZ3nHp6ss4hD3VLAnEGU, user_pool_token_account: 5LdNBh1hz4cJNz6ExGrC9xSGE6rhDFAJ5yxwrSUuKm3E, pool_base_token_account: rBCM7hDGMby83uaYqWJgf6W2aVRhQcw3nbh7PTVo3qU, pool_quote_token_account: 553TGMAUGp4tmMA2grciypsrGZMXbd9rtANi4zo1HrDT }

PumpSwapBuyEvent { metadata: EventMetadata { signature: 2P6VfM9JEqWaRpbWfZ4dL3HdEvGSj1i5LJfmhU55MYCpnVCqscSQiKmzhmZrXLTUYZE19BbWMwcBucb8NvvCLqfZ, slot: 364468398, transaction_index: None, block_time: 1756936108, block_time_ms: 1756936108000, recv_us: 1757390598179504, handle_us: 1561, protocol: PumpSwap, event_type: PumpSwapBuy, program_id: pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA, swap_data: Some(SwapData { from_mint: So11111111111111111111111111111111111111112, to_mint: 65zhLXSxBL87Q4bDuLKjo5KnaALNTQe2Pi5FznJCpump, from_amount: 152106387, to_amount: 365070093457, description: None }), outer_index: 4, inner_index: None }, timestamp: 1756936108, base_amount_out: 365070093457, max_quote_amount_in: 165000000, user_base_token_reserves: 0, user_quote_token_reserves: 2340127201, pool_base_token_reserves: 206900000000000, pool_quote_token_reserves: 84990359583, quote_amount_in: 150228529, lp_fee_basis_points: 2, lp_fee: 30046, protocol_fee_basis_points: 93, protocol_fee: 1397126, quote_amount_in_with_lp_fee: 150258575, user_quote_amount_in: 152106387, pool: GJReBf9GDfy1GNScKJZe98MHSWNtpmMd86KYzxvP68UK, user: BnnNJJgy9w2MLQ9XBKJKG9FQa2r9qdW7u5VpzEkwUcc3, user_base_token_account: 37hB2pdAynS3fav4YE5muHbX33om5HqpygZYTc9EGaeQ, user_quote_token_account: 3UTnCnu8oseGb7pnCBc3qbgJfKFKSXmrhV376wagzNtY, protocol_fee_recipient: 7VtfL8fvgNfhz17qKRMjzQEXgbdpnHHHQRh54R9jP2RJ, protocol_fee_recipient_token_account: 7GFUN3bWzJMKMRZ34JLsvcqdssDbXnp589SiE33KVwcC, coin_creator: DZExCWF6ySE6QSaKyZgcRctbrZ3nHp6ss4hD3VLAnEGU, coin_creator_fee_basis_points: 30, coin_creator_fee: 450686, track_volume: false, total_unclaimed_tokens: 0, total_claimed_tokens: 0, current_sol_volume: 0, last_update_timestamp: 0, base_mint: 65zhLXSxBL87Q4bDuLKjo5KnaALNTQe2Pi5FznJCpump, quote_mint: So11111111111111111111111111111111111111112, pool_base_token_account: rBCM7hDGMby83uaYqWJgf6W2aVRhQcw3nbh7PTVo3qU, pool_quote_token_account: 553TGMAUGp4tmMA2grciypsrGZMXbd9rtANi4zo1HrDT, coin_creator_vault_ata: 5QiyuWqnNZ8z9kosPwNr8HdKbUEt1ncqPbAVVn9Jchfp, coin_creator_vault_authority: B3cty2WBFcKXCV594uFnnTWEJBqd3zVUChRDzFtdSS8R, base_token_program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA, quote_token_program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA }
```