### PR TITLE
fix: add no-entrypoint feature to spl-token dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,8 +68,8 @@ crossbeam = "0.8.4"
 crossbeam-queue = "0.3.12"
 parking_lot = "0.12.5"
 wide = "1.1.0"
-spl-token = "9.0.0"
-spl-token-2022 = "10.0.0"
+spl-token = { version = "9.0.0", default-features = false, features = ["no-entrypoint"] }
+spl-token-2022 = { version = "10.0.0", default-features = false, features = ["no-entrypoint"] }
 solana-commitment-config = { version = "3.1.0", features = ["serde"] }
 tonic-prost = "0.14.2"
 


### PR DESCRIPTION
When building examples, the linker fails with multiple definition of entrypoint error because both spl-token and spl-token-2022 define the entrypoint() function by default.

Error:
error: ld returned 1 exit status
multiple definition of 'entrypoint'
spl_token-*.rlib: previous definition here

This SDK is an off-chain client library, not an on-chain program deployed to validators. The entrypoint() function is only needed for on-chain Solana programs. Client libraries only need the types and structs for parsing account data.

Fix: Add no-entrypoint feature to exclude the entrypoint symbol from compilation.

Before:
spl-token = "9.0.0"
spl-token-2022 = "10.0.0"

After:
spl-token = { version = "9.0.0", default-features = false, features = ["no-entrypoint"] }
spl-token-2022 = { version = "10.0.0", default-features = false, features = ["no-entrypoint"] }