### PR TITLE
fix: use current parser and program IDLs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ sdk-perf-stats = ["sol-parser-sdk/perf-stats"]
 sdk-ultra-perf = ["sol-parser-sdk/ultra-perf"]
 
 [dependencies]
-sol-parser-sdk = { version = "0.6.1", default-features = false }
+sol-parser-sdk = { version = "0.6.2", default-features = false }
 solana-sdk = "3.0.0"
 solana-client = "3.1.12"
 solana-transaction-status = "3.1.12"

--- a/idl/meteora_amm.json
+++ b/idl/meteora_amm.json
@@ -1,2322 +1,3111 @@
 {
-  "version": "0.4.12",
-  "name": "amm",
-  "docs": ["Program for AMM"],
+  "address": "Eo7WjKq67rjJQSZxS6z3YkapzY3eMj6Xy8X5EQVn5UaB",
+  "metadata": {
+    "name": "dynamic_amm",
+    "version": "0.5.2",
+    "spec": "0.1.0"
+  },
+  "docs": [
+    "Program for AMM"
+  ],
   "instructions": [
     {
-      "name": "initializePermissionedPool",
-      "docs": ["Initialize a new permissioned pool."],
+      "name": "initialize_permissioned_pool",
+      "docs": [
+        "Initialize a new permissioned pool."
+      ],
+      "discriminator": [
+        77,
+        85,
+        178,
+        157,
+        50,
+        48,
+        212,
+        126
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": true,
-          "docs": ["Pool account (arbitrary address)"]
+          "docs": [
+            "Pool account (arbitrary address)"
+          ],
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
         },
         {
-          "name": "tokenAMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token A mint of the pool. Eg: USDT"]
+          "name": "token_a_mint",
+          "docs": [
+            "Token A mint of the pool. Eg: USDT"
+          ]
         },
         {
-          "name": "tokenBMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token B mint of the pool. Eg: USDC"]
+          "name": "token_b_mint",
+          "docs": [
+            "Token B mint of the pool. Eg: USDC"
+          ]
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault A"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault B"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "adminTokenA",
-          "isMut": true,
-          "isSigner": false,
+          "name": "admin_token_a",
           "docs": [
             "Admin token account for pool token A mint. Used to bootstrap the pool with initial liquidity."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "adminTokenB",
-          "isMut": true,
-          "isSigner": false,
+          "name": "admin_token_b",
           "docs": [
             "Admin token account for pool token B mint. Used to bootstrap the pool with initial liquidity."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "adminPoolLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "admin_pool_lp",
           "docs": [
             "Admin pool LP token account. Used to receive LP during first deposit (initialize pool)",
             "Admin pool LP token account. Used to receive LP during first deposit (initialize pool)"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "adminTokenAFee",
-          "isMut": true,
-          "isSigner": false,
+          "name": "protocol_token_a_fee",
           "docs": [
-            "Admin fee token account for token A. Used to receive trading fee."
-          ]
+            "Protocol fee token account for token A. Used to receive trading fee."
+          ],
+          "writable": true
         },
         {
-          "name": "adminTokenBFee",
-          "isMut": true,
-          "isSigner": false,
+          "name": "protocol_token_b_fee",
           "docs": [
-            "Admin fee token account for token B. Used to receive trading fee."
-          ]
+            "Protocol fee token account for token B. Used to receive trading fee."
+          ],
+          "writable": true
         },
         {
           "name": "admin",
-          "isMut": true,
-          "isSigner": true,
           "docs": [
             "Admin account. This account will be the admin of the pool, and the payer for PDA during initialize pool."
-          ]
+          ],
+          "writable": true,
+          "signer": true
         },
-        { "name": "feeOwner", "isMut": false, "isSigner": false },
+        {
+          "name": "fee_owner"
+        },
         {
           "name": "rent",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Rent account."]
+          "docs": [
+            "Rent account."
+          ]
         },
-        { "name": "mintMetadata", "isMut": true, "isSigner": false },
-        { "name": "metadataProgram", "isMut": false, "isSigner": false },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "mint_metadata",
+          "writable": true
+        },
+        {
+          "name": "metadata_program"
+        },
+        {
+          "name": "vault_program",
           "docs": [
             "Vault program. The pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
-        },
-        {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Associated token program."]
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["System program."]
-        }
-      ],
-      "args": [{ "name": "curveType", "type": { "defined": "CurveType" } }]
-    },
-    {
-      "name": "initializePermissionlessPool",
-      "docs": ["Initialize a new permissionless pool."],
-      "accounts": [
-        {
-          "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA address)"]
-        },
-        {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
-        },
-        {
-          "name": "tokenAMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token A mint of the pool. Eg: USDT"]
-        },
-        {
-          "name": "tokenBMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token B mint of the pool. Eg: USDC"]
-        },
-        {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "token_program",
           "docs": [
-            "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
+            "Token program."
           ]
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "associated_token_program",
           "docs": [
-            "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
+            "Associated token program."
           ]
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault A"]
-        },
-        {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault B"]
-        },
-        {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault A"]
-        },
-        {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault B"]
-        },
-        {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "system_program",
           "docs": [
-            "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
+            "System program."
           ]
-        },
-        {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "LP token account of vault B. Used to receive/burn vault LP upon deposit/withdraw from the vault."
-          ]
-        },
-        {
-          "name": "payerTokenA",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Payer token account for pool token A mint. Used to bootstrap the pool with initial liquidity."
-          ]
-        },
-        {
-          "name": "payerTokenB",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Admin token account for pool token B mint. Used to bootstrap the pool with initial liquidity."
-          ]
-        },
-        { "name": "payerPoolLp", "isMut": true, "isSigner": false },
-        {
-          "name": "adminTokenAFee",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Admin fee token account for token A. Used to receive trading fee."
-          ]
-        },
-        {
-          "name": "adminTokenBFee",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Admin fee token account for token B. Used to receive trading fee."
-          ]
-        },
-        {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true,
-          "docs": [
-            "Admin account. This account will be the admin of the pool, and the payer for PDA during initialize pool."
-          ]
-        },
-        { "name": "feeOwner", "isMut": false, "isSigner": false },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Rent account."]
-        },
-        { "name": "mintMetadata", "isMut": true, "isSigner": false },
-        { "name": "metadataProgram", "isMut": false, "isSigner": false },
-        {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Vault program. The pool will deposit/withdraw liquidity from the vault."
-          ]
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
-        },
-        {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Associated token program."]
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["System program."]
         }
       ],
       "args": [
-        { "name": "curveType", "type": { "defined": "CurveType" } },
-        { "name": "tokenAAmount", "type": "u64" },
-        { "name": "tokenBAmount", "type": "u64" }
+        {
+          "name": "curve_type",
+          "type": {
+            "defined": {
+              "name": "CurveType"
+            }
+          }
+        }
       ]
     },
     {
-      "name": "initializePermissionlessPoolWithFeeTier",
-      "docs": ["Initialize a new permissionless pool with customized fee tier"],
+      "name": "initialize_permissionless_pool",
+      "docs": [
+        "Initialize a new permissionless pool."
+      ],
+      "discriminator": [
+        118,
+        173,
+        41,
+        157,
+        173,
+        72,
+        97,
+        103
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA address)"]
+          "docs": [
+            "Pool account (PDA address)"
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
         },
         {
-          "name": "tokenAMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token A mint of the pool. Eg: USDT"]
+          "name": "token_a_mint",
+          "docs": [
+            "Token A mint of the pool. Eg: USDT"
+          ]
         },
         {
-          "name": "tokenBMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token B mint of the pool. Eg: USDC"]
+          "name": "token_b_mint",
+          "docs": [
+            "Token B mint of the pool. Eg: USDC"
+          ]
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault A"]
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault B"]
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault A"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault B"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "payerTokenA",
-          "isMut": true,
-          "isSigner": false,
+          "name": "payer_token_a",
           "docs": [
             "Payer token account for pool token A mint. Used to bootstrap the pool with initial liquidity."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "payerTokenB",
-          "isMut": true,
-          "isSigner": false,
+          "name": "payer_token_b",
           "docs": [
             "Admin token account for pool token B mint. Used to bootstrap the pool with initial liquidity."
-          ]
-        },
-        { "name": "payerPoolLp", "isMut": true, "isSigner": false },
-        {
-          "name": "adminTokenAFee",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Admin fee token account for token A. Used to receive trading fee."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "adminTokenBFee",
-          "isMut": true,
-          "isSigner": false,
+          "name": "payer_pool_lp",
+          "writable": true
+        },
+        {
+          "name": "protocol_token_a_fee",
           "docs": [
-            "Admin fee token account for token B. Used to receive trading fee."
-          ]
+            "Protocol fee token account for token A. Used to receive trading fee."
+          ],
+          "writable": true
+        },
+        {
+          "name": "protocol_token_b_fee",
+          "docs": [
+            "Protocol fee token account for token B. Used to receive trading fee."
+          ],
+          "writable": true
         },
         {
           "name": "payer",
-          "isMut": true,
-          "isSigner": true,
           "docs": [
             "Admin account. This account will be the admin of the pool, and the payer for PDA during initialize pool."
-          ]
+          ],
+          "writable": true,
+          "signer": true
         },
-        { "name": "feeOwner", "isMut": false, "isSigner": false },
+        {
+          "name": "fee_owner"
+        },
         {
           "name": "rent",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Rent account."]
+          "docs": [
+            "Rent account."
+          ]
         },
-        { "name": "mintMetadata", "isMut": true, "isSigner": false },
-        { "name": "metadataProgram", "isMut": false, "isSigner": false },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "mint_metadata",
+          "writable": true
+        },
+        {
+          "name": "metadata_program"
+        },
+        {
+          "name": "vault_program",
           "docs": [
             "Vault program. The pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
         },
         {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Associated token program."]
+          "name": "associated_token_program",
+          "docs": [
+            "Associated token program."
+          ]
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["System program."]
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ]
         }
       ],
       "args": [
-        { "name": "curveType", "type": { "defined": "CurveType" } },
-        { "name": "tradeFeeBps", "type": "u64" },
-        { "name": "tokenAAmount", "type": "u64" },
-        { "name": "tokenBAmount", "type": "u64" }
+        {
+          "name": "curve_type",
+          "type": {
+            "defined": {
+              "name": "CurveType"
+            }
+          }
+        },
+        {
+          "name": "token_a_amount",
+          "type": "u64"
+        },
+        {
+          "name": "token_b_amount",
+          "type": "u64"
+        }
       ]
     },
     {
-      "name": "enableOrDisablePool",
+      "name": "initialize_permissionless_pool_with_fee_tier",
+      "docs": [
+        "Initialize a new permissionless pool with customized fee tier"
+      ],
+      "discriminator": [
+        6,
+        135,
+        68,
+        147,
+        229,
+        82,
+        169,
+        113
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "docs": [
+            "Pool account (PDA address)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_a_mint",
+          "docs": [
+            "Token A mint of the pool. Eg: USDT"
+          ]
+        },
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "Token B mint of the pool. Eg: USDC"
+          ]
+        },
+        {
+          "name": "a_vault",
+          "docs": [
+            "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault",
+          "docs": [
+            "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault A"
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault B"
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp",
+          "docs": [
+            "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp",
+          "docs": [
+            "LP token account of vault B. Used to receive/burn vault LP upon deposit/withdraw from the vault."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_a",
+          "docs": [
+            "Payer token account for pool token A mint. Used to bootstrap the pool with initial liquidity."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_b",
+          "docs": [
+            "Admin token account for pool token B mint. Used to bootstrap the pool with initial liquidity."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_pool_lp",
+          "writable": true
+        },
+        {
+          "name": "protocol_token_a_fee",
+          "docs": [
+            "Protocol fee token account for token A. Used to receive trading fee."
+          ],
+          "writable": true
+        },
+        {
+          "name": "protocol_token_b_fee",
+          "docs": [
+            "Protocol fee token account for token B. Used to receive trading fee."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "Admin account. This account will be the admin of the pool, and the payer for PDA during initialize pool."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "fee_owner"
+        },
+        {
+          "name": "rent",
+          "docs": [
+            "Rent account."
+          ]
+        },
+        {
+          "name": "mint_metadata",
+          "writable": true
+        },
+        {
+          "name": "metadata_program"
+        },
+        {
+          "name": "vault_program",
+          "docs": [
+            "Vault program. The pool will deposit/withdraw liquidity from the vault."
+          ]
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Associated token program."
+          ]
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "curve_type",
+          "type": {
+            "defined": {
+              "name": "CurveType"
+            }
+          }
+        },
+        {
+          "name": "trade_fee_bps",
+          "type": "u64"
+        },
+        {
+          "name": "token_a_amount",
+          "type": "u64"
+        },
+        {
+          "name": "token_b_amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "enable_or_disable_pool",
       "docs": [
         "Enable or disable a pool. A disabled pool allow only remove balanced liquidity operation."
       ],
+      "discriminator": [
+        128,
+        6,
+        228,
+        131,
+        55,
+        161,
+        52,
+        169
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
         },
         {
           "name": "admin",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["Admin account. Must be owner of the pool."]
+          "docs": [
+            "Admin account. Must be owner of the pool."
+          ],
+          "signer": true
         }
       ],
-      "args": [{ "name": "enable", "type": "bool" }]
+      "args": [
+        {
+          "name": "enable",
+          "type": "bool"
+        }
+      ]
     },
     {
       "name": "swap",
       "docs": [
         "Swap token A to B, or vice versa. An amount of trading fee will be charged for liquidity provider, and the admin of the pool."
       ],
+      "discriminator": [
+        248,
+        198,
+        158,
+        145,
+        225,
+        117,
+        135,
+        200
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
         },
         {
-          "name": "userSourceToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_source_token",
           "docs": [
             "User token account. Token from this account will be transfer into the vault by the pool in exchange for another token of the pool."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userDestinationToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_destination_token",
           "docs": [
             "User token account. The exchanged token will be transfer into this account from the pool."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault A"]
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault B"]
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Lp token mint of vault a"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "Lp token mint of vault a"
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Lp token mint of vault b"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "Lp token mint of vault b"
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "adminTokenFee",
-          "isMut": true,
-          "isSigner": false,
+          "name": "protocol_token_fee",
           "docs": [
-            "Admin fee token account. Used to receive trading fee. It's mint field must matched with user_source_token mint field."
-          ]
+            "Protocol fee token account. Used to receive trading fee. It's mint field must matched with user_source_token mint field."
+          ],
+          "writable": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["User account. Must be owner of user_source_token."]
+          "docs": [
+            "User account. Must be owner of user_source_token."
+          ],
+          "signer": true
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. the pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
         }
       ],
       "args": [
-        { "name": "inAmount", "type": "u64" },
-        { "name": "minimumOutAmount", "type": "u64" }
+        {
+          "name": "in_amount",
+          "type": "u64"
+        },
+        {
+          "name": "minimum_out_amount",
+          "type": "u64"
+        }
       ]
     },
     {
-      "name": "removeLiquiditySingleSide",
+      "name": "remove_liquidity_single_side",
       "docs": [
         "Withdraw only single token from the pool. Only supported by pool with stable swap curve."
+      ],
+      "discriminator": [
+        84,
+        84,
+        177,
+        66,
+        254,
+        185,
+        10,
+        251
       ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
         },
         {
-          "name": "userPoolLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_pool_lp",
           "docs": [
             "User pool lp token account. LP will be burned from this account upon success liquidity removal."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault A"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault B"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault A"]
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault B"]
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "userDestinationToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_destination_token",
           "docs": [
             "User token account to receive token upon success liquidity removal."
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["User account. Must be owner of the user_pool_lp account."]
+          "docs": [
+            "User account. Must be owner of the user_pool_lp account."
+          ],
+          "signer": true
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. The pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
         }
       ],
       "args": [
-        { "name": "poolTokenAmount", "type": "u64" },
-        { "name": "minimumOutAmount", "type": "u64" }
+        {
+          "name": "pool_token_amount",
+          "type": "u64"
+        },
+        {
+          "name": "minimum_out_amount",
+          "type": "u64"
+        }
       ]
     },
     {
-      "name": "addImbalanceLiquidity",
+      "name": "add_imbalance_liquidity",
       "docs": [
         "Deposit tokens to the pool in an imbalance ratio. Only supported by pool with stable swap curve."
       ],
+      "discriminator": [
+        79,
+        35,
+        122,
+        84,
+        173,
+        15,
+        93,
+        191
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
         },
         {
-          "name": "userPoolLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_pool_lp",
           "docs": [
             "user pool lp token account. lp will be burned from this account upon success liquidity removal."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault a"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault a"
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault b"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault b"
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault A"]
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault B"]
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "userAToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_a_token",
           "docs": [
             "User token A account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userBToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_b_token",
           "docs": [
             "User token B account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true,
           "docs": [
             "User account. Must be owner of user_a_token, and user_b_token."
-          ]
+          ],
+          "signer": true
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. the pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
         }
       ],
       "args": [
-        { "name": "minimumPoolTokenAmount", "type": "u64" },
-        { "name": "tokenAAmount", "type": "u64" },
-        { "name": "tokenBAmount", "type": "u64" }
+        {
+          "name": "minimum_pool_token_amount",
+          "type": "u64"
+        },
+        {
+          "name": "token_a_amount",
+          "type": "u64"
+        },
+        {
+          "name": "token_b_amount",
+          "type": "u64"
+        }
       ]
     },
     {
-      "name": "removeBalanceLiquidity",
+      "name": "remove_balance_liquidity",
       "docs": [
         "Withdraw tokens from the pool in a balanced ratio. User will still able to withdraw from pool even the pool is disabled. This allow user to exit their liquidity when there's some unforeseen event happen."
       ],
+      "discriminator": [
+        133,
+        109,
+        44,
+        179,
+        56,
+        238,
+        114,
+        33
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
         },
         {
-          "name": "userPoolLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_pool_lp",
           "docs": [
             "user pool lp token account. lp will be burned from this account upon success liquidity removal."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault a"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault a"
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault b"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault b"
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault A"]
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault B"]
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "userAToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_a_token",
           "docs": [
             "User token A account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userBToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_b_token",
           "docs": [
             "User token B account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true,
           "docs": [
             "User account. Must be owner of user_a_token, and user_b_token."
-          ]
+          ],
+          "signer": true
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. the pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
         }
       ],
       "args": [
-        { "name": "poolTokenAmount", "type": "u64" },
-        { "name": "minimumATokenOut", "type": "u64" },
-        { "name": "minimumBTokenOut", "type": "u64" }
+        {
+          "name": "pool_token_amount",
+          "type": "u64"
+        },
+        {
+          "name": "minimum_a_token_out",
+          "type": "u64"
+        },
+        {
+          "name": "minimum_b_token_out",
+          "type": "u64"
+        }
       ]
     },
     {
-      "name": "addBalanceLiquidity",
-      "docs": ["Deposit tokens to the pool in a balanced ratio."],
+      "name": "add_balance_liquidity",
+      "docs": [
+        "Deposit tokens to the pool in a balanced ratio."
+      ],
+      "discriminator": [
+        168,
+        227,
+        50,
+        62,
+        189,
+        171,
+        84,
+        176
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
         },
         {
-          "name": "userPoolLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_pool_lp",
           "docs": [
             "user pool lp token account. lp will be burned from this account upon success liquidity removal."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault a"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault a"
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault b"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault b"
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault A"]
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault B"]
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "userAToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_a_token",
           "docs": [
             "User token A account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userBToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_b_token",
           "docs": [
             "User token B account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true,
           "docs": [
             "User account. Must be owner of user_a_token, and user_b_token."
-          ]
+          ],
+          "signer": true
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. the pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
         }
       ],
       "args": [
-        { "name": "poolTokenAmount", "type": "u64" },
-        { "name": "maximumTokenAAmount", "type": "u64" },
-        { "name": "maximumTokenBAmount", "type": "u64" }
+        {
+          "name": "pool_token_amount",
+          "type": "u64"
+        },
+        {
+          "name": "maximum_token_a_amount",
+          "type": "u64"
+        },
+        {
+          "name": "maximum_token_b_amount",
+          "type": "u64"
+        }
       ]
     },
     {
-      "name": "setPoolFees",
-      "docs": ["Update trading fee charged for liquidity provider, and admin."],
+      "name": "set_pool_fees",
+      "docs": [
+        "Update trading fee charged for liquidity provider, and admin."
+      ],
+      "discriminator": [
+        102,
+        44,
+        158,
+        54,
+        205,
+        37,
+        126,
+        78
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
         },
         {
-          "name": "admin",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["Admin account. Must be owner of the pool."]
+          "name": "fee_operator",
+          "docs": [
+            "Fee operator account"
+          ],
+          "signer": true
         }
       ],
-      "args": [{ "name": "fees", "type": { "defined": "PoolFees" } }]
+      "args": [
+        {
+          "name": "fees",
+          "type": {
+            "defined": {
+              "name": "PoolFees"
+            }
+          }
+        },
+        {
+          "name": "new_partner_fee_numerator",
+          "type": "u64"
+        }
+      ]
     },
     {
-      "name": "overrideCurveParam",
+      "name": "override_curve_param",
       "docs": [
         "Update swap curve parameters. This function do not allow update of curve type. For example: stable swap curve to constant product curve. Only supported by pool with stable swap curve.",
         "Only amp is allowed to be override. The other attributes of stable swap curve will be ignored."
       ],
+      "discriminator": [
+        98,
+        86,
+        204,
+        51,
+        94,
+        71,
+        69,
+        187
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
         },
         {
           "name": "admin",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["Admin account. Must be owner of the pool."]
+          "docs": [
+            "Admin account."
+          ],
+          "signer": true
         }
       ],
-      "args": [{ "name": "curveType", "type": { "defined": "CurveType" } }]
+      "args": [
+        {
+          "name": "curve_type",
+          "type": {
+            "defined": {
+              "name": "CurveType"
+            }
+          }
+        }
+      ]
     },
     {
-      "name": "transferAdmin",
-      "docs": ["Transfer the admin of the pool to new admin."],
+      "name": "get_pool_info",
+      "docs": [
+        "Get the general information of the pool."
+      ],
+      "discriminator": [
+        9,
+        48,
+        220,
+        101,
+        22,
+        240,
+        78,
+        200
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ]
         },
         {
-          "name": "admin",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["Admin account. Must be owner of the pool."]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ]
         },
         {
-          "name": "newAdmin",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["New admin account."]
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "getPoolInfo",
-      "docs": ["Get the general information of the pool."],
-      "accounts": [
-        {
-          "name": "pool",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
-        },
-        {
-          "name": "lpMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
-        },
-        {
-          "name": "aVaultLp",
-          "isMut": false,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
           ]
         },
         {
-          "name": "bVaultLp",
-          "isMut": false,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
           ]
         },
         {
-          "name": "aVault",
-          "isMut": false,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
           ]
         },
         {
-          "name": "bVault",
-          "isMut": false,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
           ]
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["LP token mint of vault a"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault a"
+          ]
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["LP token mint of vault b"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault b"
+          ]
         }
       ],
       "args": []
     },
     {
-      "name": "bootstrapLiquidity",
-      "docs": ["Bootstrap the pool when liquidity is depleted."],
+      "name": "bootstrap_liquidity",
+      "docs": [
+        "Bootstrap the pool when liquidity is depleted."
+      ],
+      "discriminator": [
+        4,
+        228,
+        215,
+        71,
+        225,
+        253,
+        119,
+        206
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
         },
         {
-          "name": "userPoolLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_pool_lp",
           "docs": [
             "user pool lp token account. lp will be burned from this account upon success liquidity removal."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault a"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault a"
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault b"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault b"
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault A"]
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault B"]
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "userAToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_a_token",
           "docs": [
             "User token A account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userBToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_b_token",
           "docs": [
             "User token B account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true,
           "docs": [
             "User account. Must be owner of user_a_token, and user_b_token."
-          ]
+          ],
+          "signer": true
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. the pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
         }
       ],
       "args": [
-        { "name": "tokenAAmount", "type": "u64" },
-        { "name": "tokenBAmount", "type": "u64" }
+        {
+          "name": "token_a_amount",
+          "type": "u64"
+        },
+        {
+          "name": "token_b_amount",
+          "type": "u64"
+        }
       ]
     },
     {
-      "name": "migrateFeeAccount",
-      "docs": ["Migrate old token fee owner to PDA"],
+      "name": "create_mint_metadata",
+      "docs": [
+        "Create mint metadata account for old pools"
+      ],
+      "discriminator": [
+        13,
+        70,
+        168,
+        41,
+        250,
+        100,
+        148,
+        90
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account"]
-        },
-        {
-          "name": "aVaultLp",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["A vault LP token account of the pool."]
-        },
-        {
-          "name": "adminTokenAFee",
-          "isMut": true,
-          "isSigner": false,
           "docs": [
-            "Admin fee token account for token A. Used to receive trading fee."
+            "Pool account"
           ]
         },
         {
-          "name": "adminTokenBFee",
-          "isMut": true,
-          "isSigner": false,
+          "name": "lp_mint",
           "docs": [
-            "Admin fee token account for token B. Used to receive trading fee."
+            "LP mint account of the pool"
           ]
         },
         {
-          "name": "tokenAMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token A mint"]
+          "name": "a_vault_lp",
+          "docs": [
+            "Vault A LP account of the pool"
+          ]
         },
         {
-          "name": "tokenBMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token B mint"]
+          "name": "mint_metadata",
+          "writable": true
         },
         {
-          "name": "newAdminTokenAFee",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token fee account. Controlled by pool a_vault_lp PDA."]
+          "name": "metadata_program"
         },
         {
-          "name": "newAdminTokenBFee",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token fee account. Controlled by pool a_vault_lp PDA."]
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ]
         },
         {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true,
-          "docs": ["Admin account. Must be owner of the pool."]
-        },
-        {
-          "name": "treasuryTokenAFee",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Treasury token a fee ATA."]
-        },
-        {
-          "name": "treasuryTokenBFee",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Treasury token b fee ATA."]
-        },
-        {
-          "name": "treasury",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["Treasury signer"]
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["System program."]
+          "name": "payer",
+          "docs": [
+            "Payer"
+          ],
+          "writable": true,
+          "signer": true
         }
       ],
       "args": []
     },
     {
-      "name": "createMintMetadata",
-      "docs": ["Create mint metadata account for old pools"],
-      "accounts": [
-        {
-          "name": "pool",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Pool account"]
-        },
-        {
-          "name": "lpMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["LP mint account of the pool"]
-        },
-        {
-          "name": "aVaultLp",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Vault A LP account of the pool"]
-        },
-        { "name": "mintMetadata", "isMut": true, "isSigner": false },
-        { "name": "metadataProgram", "isMut": false, "isSigner": false },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["System program."]
-        },
-        { "name": "payer", "isMut": true, "isSigner": true, "docs": ["Payer"] }
+      "name": "create_lock_escrow",
+      "docs": [
+        "Create lock account"
       ],
-      "args": []
-    },
-    {
-      "name": "createLockEscrow",
-      "docs": ["Create lock account"],
+      "discriminator": [
+        54,
+        87,
+        165,
+        19,
+        69,
+        227,
+        218,
+        224
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Pool account"]
+          "docs": [
+            "Pool account"
+          ]
         },
         {
-          "name": "lockEscrow",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Lock account"]
+          "name": "lock_escrow",
+          "docs": [
+            "Lock account"
+          ],
+          "writable": true
         },
-        { "name": "owner", "isMut": false, "isSigner": false },
         {
-          "name": "lpMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "owner"
+        },
+        {
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ]
         },
         {
           "name": "payer",
-          "isMut": true,
-          "isSigner": true,
-          "docs": ["Payer account"]
+          "docs": [
+            "Payer account"
+          ],
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["System program."]
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ]
         }
       ],
       "args": []
     },
     {
       "name": "lock",
-      "docs": ["Lock Lp token"],
+      "docs": [
+        "Lock Lp token"
+      ],
+      "discriminator": [
+        21,
+        19,
+        208,
+        43,
+        237,
+        62,
+        255,
+        87
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account"]
+          "docs": [
+            "Pool account"
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ]
         },
         {
-          "name": "lockEscrow",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Lock account"]
+          "name": "lock_escrow",
+          "docs": [
+            "Lock account"
+          ],
+          "writable": true
         },
         {
           "name": "owner",
-          "isMut": true,
-          "isSigner": true,
-          "docs": ["Owner of lock account"]
+          "docs": [
+            "Can be anyone"
+          ],
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "sourceTokens",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["owner lp token account"]
+          "name": "source_tokens",
+          "docs": [
+            "owner lp token account"
+          ],
+          "writable": true
         },
         {
-          "name": "escrowVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Escrow vault"]
+          "name": "escrow_vault",
+          "docs": [
+            "Escrow vault"
+          ],
+          "writable": true
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
         },
         {
-          "name": "aVault",
-          "isMut": false,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
           ]
         },
         {
-          "name": "bVault",
-          "isMut": false,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
           ]
         },
         {
-          "name": "aVaultLp",
-          "isMut": false,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
           ]
         },
         {
-          "name": "bVaultLp",
-          "isMut": false,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
           ]
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["LP token mint of vault a"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault a"
+          ]
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["LP token mint of vault b"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault b"
+          ]
         }
       ],
-      "args": [{ "name": "amount", "type": "u64" }]
+      "args": [
+        {
+          "name": "max_amount",
+          "type": "u64"
+        }
+      ]
     },
     {
-      "name": "claimFee",
-      "docs": ["Claim fee"],
+      "name": "claim_fee",
+      "docs": [
+        "Claim fee"
+      ],
+      "discriminator": [
+        169,
+        32,
+        79,
+        137,
+        136,
+        232,
+        70,
+        137
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account"]
+          "docs": [
+            "Pool account"
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
         },
         {
-          "name": "lockEscrow",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Lock account"]
+          "name": "lock_escrow",
+          "docs": [
+            "Lock account"
+          ],
+          "writable": true
         },
         {
           "name": "owner",
-          "isMut": true,
-          "isSigner": true,
-          "docs": ["Owner of lock account"]
+          "docs": [
+            "Owner of lock account"
+          ],
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "sourceTokens",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["owner lp token account"]
+          "name": "source_tokens",
+          "docs": [
+            "owner lp token account"
+          ],
+          "writable": true
         },
         {
-          "name": "escrowVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Escrow vault"]
+          "name": "escrow_vault",
+          "docs": [
+            "Escrow vault"
+          ],
+          "writable": true
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault A"]
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault B"]
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault a"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault a"
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault b"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault b"
+          ],
+          "writable": true
         },
         {
-          "name": "userAToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_a_token",
           "docs": [
             "User token A account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userBToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_b_token",
           "docs": [
             "User token B account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. the pool will deposit/withdraw liquidity from the vault."
           ]
         }
       ],
-      "args": [{ "name": "maxAmount", "type": "u64" }]
+      "args": [
+        {
+          "name": "max_amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "create_config",
+      "docs": [
+        "Create config"
+      ],
+      "discriminator": [
+        201,
+        207,
+        243,
+        114,
+        75,
+        111,
+        47,
+        189
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "config_parameters",
+          "type": {
+            "defined": {
+              "name": "ConfigParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "close_config",
+      "docs": [
+        "Close config"
+      ],
+      "discriminator": [
+        145,
+        9,
+        72,
+        157,
+        95,
+        125,
+        61,
+        85
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initialize_permissionless_constant_product_pool_with_config",
+      "docs": [
+        "Initialize permissionless pool with config"
+      ],
+      "discriminator": [
+        7,
+        166,
+        138,
+        171,
+        206,
+        171,
+        236,
+        244
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "docs": [
+            "Pool account (PDA address)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_a_mint",
+          "docs": [
+            "Token A mint of the pool. Eg: USDT"
+          ]
+        },
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "Token B mint of the pool. Eg: USDC"
+          ]
+        },
+        {
+          "name": "a_vault",
+          "docs": [
+            "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault",
+          "docs": [
+            "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault A"
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault B"
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp",
+          "docs": [
+            "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp",
+          "docs": [
+            "LP token account of vault B. Used to receive/burn vault LP upon deposit/withdraw from the vault."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_a",
+          "docs": [
+            "Payer token account for pool token A mint. Used to bootstrap the pool with initial liquidity."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_b",
+          "docs": [
+            "Admin token account for pool token B mint. Used to bootstrap the pool with initial liquidity."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_pool_lp",
+          "writable": true
+        },
+        {
+          "name": "protocol_token_a_fee",
+          "docs": [
+            "Protocol fee token account for token A. Used to receive trading fee."
+          ],
+          "writable": true
+        },
+        {
+          "name": "protocol_token_b_fee",
+          "docs": [
+            "Protocol fee token account for token B. Used to receive trading fee."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "Admin account. This account will be the admin of the pool, and the payer for PDA during initialize pool."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "rent",
+          "docs": [
+            "Rent account."
+          ]
+        },
+        {
+          "name": "mint_metadata",
+          "writable": true
+        },
+        {
+          "name": "metadata_program"
+        },
+        {
+          "name": "vault_program",
+          "docs": [
+            "Vault program. The pool will deposit/withdraw liquidity from the vault."
+          ]
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Associated token program."
+          ]
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "token_a_amount",
+          "type": "u64"
+        },
+        {
+          "name": "token_b_amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "initialize_permissionless_constant_product_pool_with_config2",
+      "docs": [
+        "Initialize permissionless pool with config 2"
+      ],
+      "discriminator": [
+        48,
+        149,
+        220,
+        130,
+        61,
+        11,
+        9,
+        178
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "docs": [
+            "Pool account (PDA address)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_a_mint",
+          "docs": [
+            "Token A mint of the pool. Eg: USDT"
+          ]
+        },
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "Token B mint of the pool. Eg: USDC"
+          ]
+        },
+        {
+          "name": "a_vault",
+          "docs": [
+            "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault",
+          "docs": [
+            "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault A"
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault B"
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp",
+          "docs": [
+            "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp",
+          "docs": [
+            "LP token account of vault B. Used to receive/burn vault LP upon deposit/withdraw from the vault."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_a",
+          "docs": [
+            "Payer token account for pool token A mint. Used to bootstrap the pool with initial liquidity."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_b",
+          "docs": [
+            "Admin token account for pool token B mint. Used to bootstrap the pool with initial liquidity."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_pool_lp",
+          "writable": true
+        },
+        {
+          "name": "protocol_token_a_fee",
+          "docs": [
+            "Protocol fee token account for token A. Used to receive trading fee."
+          ],
+          "writable": true
+        },
+        {
+          "name": "protocol_token_b_fee",
+          "docs": [
+            "Protocol fee token account for token B. Used to receive trading fee."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "Admin account. This account will be the admin of the pool, and the payer for PDA during initialize pool."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "rent",
+          "docs": [
+            "Rent account."
+          ]
+        },
+        {
+          "name": "mint_metadata",
+          "writable": true
+        },
+        {
+          "name": "metadata_program"
+        },
+        {
+          "name": "vault_program",
+          "docs": [
+            "Vault program. The pool will deposit/withdraw liquidity from the vault."
+          ]
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Associated token program."
+          ]
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "token_a_amount",
+          "type": "u64"
+        },
+        {
+          "name": "token_b_amount",
+          "type": "u64"
+        },
+        {
+          "name": "activation_point",
+          "type": {
+            "option": "u64"
+          }
+        }
+      ]
+    },
+    {
+      "name": "initialize_customizable_permissionless_constant_product_pool",
+      "docs": [
+        "Initialize permissionless pool with customizable params"
+      ],
+      "discriminator": [
+        145,
+        24,
+        172,
+        194,
+        219,
+        125,
+        3,
+        190
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "docs": [
+            "Pool account (PDA address)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_a_mint",
+          "docs": [
+            "Token A mint of the pool. Eg: USDT"
+          ]
+        },
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "Token B mint of the pool. Eg: USDC"
+          ]
+        },
+        {
+          "name": "a_vault",
+          "docs": [
+            "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault",
+          "docs": [
+            "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault A"
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault B"
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp",
+          "docs": [
+            "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp",
+          "docs": [
+            "LP token account of vault B. Used to receive/burn vault LP upon deposit/withdraw from the vault."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_a",
+          "docs": [
+            "Payer token account for pool token A mint. Used to bootstrap the pool with initial liquidity."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_b",
+          "docs": [
+            "Admin token account for pool token B mint. Used to bootstrap the pool with initial liquidity."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_pool_lp",
+          "writable": true
+        },
+        {
+          "name": "protocol_token_a_fee",
+          "docs": [
+            "Protocol fee token account for token A. Used to receive trading fee."
+          ],
+          "writable": true
+        },
+        {
+          "name": "protocol_token_b_fee",
+          "docs": [
+            "Protocol fee token account for token B. Used to receive trading fee."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "Admin account. This account will be the admin of the pool, and the payer for PDA during initialize pool."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "rent",
+          "docs": [
+            "Rent account."
+          ]
+        },
+        {
+          "name": "mint_metadata",
+          "writable": true
+        },
+        {
+          "name": "metadata_program"
+        },
+        {
+          "name": "vault_program",
+          "docs": [
+            "Vault program. The pool will deposit/withdraw liquidity from the vault."
+          ]
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Associated token program."
+          ]
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "token_a_amount",
+          "type": "u64"
+        },
+        {
+          "name": "token_b_amount",
+          "type": "u64"
+        },
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "CustomizableParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "update_activation_point",
+      "docs": [
+        "Update activation slot"
+      ],
+      "discriminator": [
+        150,
+        62,
+        125,
+        219,
+        171,
+        220,
+        26,
+        237
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "docs": [
+            "Admin account."
+          ],
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "new_activation_point",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "withdraw_protocol_fees",
+      "docs": [
+        "Withdraw protocol fee"
+      ],
+      "discriminator": [
+        11,
+        68,
+        165,
+        98,
+        18,
+        208,
+        134,
+        73
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "docs": [
+            "Pool account (PDA)"
+          ]
+        },
+        {
+          "name": "a_vault_lp"
+        },
+        {
+          "name": "protocol_token_a_fee",
+          "writable": true
+        },
+        {
+          "name": "protocol_token_b_fee",
+          "writable": true
+        },
+        {
+          "name": "treasury_token_a",
+          "writable": true
+        },
+        {
+          "name": "treasury_token_b",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "set_whitelisted_vault",
+      "docs": [
+        "Set whitelisted vault"
+      ],
+      "discriminator": [
+        12,
+        148,
+        94,
+        42,
+        55,
+        57,
+        83,
+        247
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "whitelisted_vault",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "partner_claim_fee",
+      "docs": [
+        "Partner claim fee"
+      ],
+      "discriminator": [
+        57,
+        53,
+        176,
+        30,
+        123,
+        70,
+        52,
+        64
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp"
+        },
+        {
+          "name": "protocol_token_a_fee",
+          "writable": true
+        },
+        {
+          "name": "protocol_token_b_fee",
+          "writable": true
+        },
+        {
+          "name": "partner_token_a",
+          "writable": true
+        },
+        {
+          "name": "partner_token_b",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "partner_authority",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount_a",
+          "type": "u64"
+        },
+        {
+          "name": "max_amount_b",
+          "type": "u64"
+        }
+      ]
     }
   ],
   "accounts": [
     {
-      "name": "Pool",
-      "docs": ["State of pool account"],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "lpMint",
-            "docs": ["LP token mint of the pool"],
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenAMint",
-            "docs": ["Token A mint of the pool. Eg: USDT"],
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenBMint",
-            "docs": ["Token B mint of the pool. Eg: USDC"],
-            "type": "publicKey"
-          },
-          {
-            "name": "aVault",
-            "docs": [
-              "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "bVault",
-            "docs": [
-              "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "aVaultLp",
-            "docs": [
-              "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "bVaultLp",
-            "docs": [
-              "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "aVaultLpBump",
-            "docs": ["\"A\" vault lp bump. Used to create signer seeds."],
-            "type": "u8"
-          },
-          {
-            "name": "enabled",
-            "docs": [
-              "Flag to determine whether the pool is enabled, or disabled."
-            ],
-            "type": "bool"
-          },
-          {
-            "name": "adminTokenAFee",
-            "docs": [
-              "Admin fee token account for token A. Used to receive trading fee."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "adminTokenBFee",
-            "docs": [
-              "Admin fee token account for token B. Used to receive trading fee."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "admin",
-            "docs": ["Owner of the pool."],
-            "type": "publicKey"
-          },
-          {
-            "name": "fees",
-            "docs": ["Store the fee charges setting."],
-            "type": { "defined": "PoolFees" }
-          },
-          {
-            "name": "poolType",
-            "docs": ["Pool type"],
-            "type": { "defined": "PoolType" }
-          },
-          {
-            "name": "stake",
-            "docs": ["Stake pubkey of SPL stake pool"],
-            "type": "publicKey"
-          },
-          {
-            "name": "totalLockedLp",
-            "docs": ["Total locked lp token"],
-            "type": "u64"
-          },
-          {
-            "name": "padding",
-            "docs": ["Padding for future pool field"],
-            "type": { "defined": "Padding" }
-          },
-          {
-            "name": "curveType",
-            "docs": ["The type of the swap curve supported by the pool."],
-            "type": { "defined": "CurveType" }
-          }
-        ]
-      }
+      "name": "Config",
+      "discriminator": [
+        155,
+        12,
+        170,
+        224,
+        30,
+        250,
+        204,
+        130
+      ]
     },
     {
       "name": "LockEscrow",
-      "docs": ["State of lock escrow account"],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          { "name": "pool", "docs": ["Pool address"], "type": "publicKey" },
-          { "name": "owner", "docs": ["Owner address"], "type": "publicKey" },
-          {
-            "name": "escrowVault",
-            "docs": ["Vault address, store the lock user lock"],
-            "type": "publicKey"
-          },
-          { "name": "bump", "docs": ["bump, used to sign"], "type": "u8" },
-          {
-            "name": "totalLockedAmount",
-            "docs": ["Total locked amount"],
-            "type": "u64"
-          },
-          {
-            "name": "lpPerToken",
-            "docs": ["Lp per token, virtual price of lp token"],
-            "type": "u128"
-          },
-          {
-            "name": "unclaimedFeePending",
-            "docs": ["Unclaimed fee pending"],
-            "type": "u64"
-          },
-          {
-            "name": "aFee",
-            "docs": ["Total a fee claimed so far"],
-            "type": "u64"
-          },
-          {
-            "name": "bFee",
-            "docs": ["Total b fee claimed so far"],
-            "type": "u64"
-          }
-        ]
-      }
-    }
-  ],
-  "types": [
-    {
-      "name": "TokenMultiplier",
-      "docs": [
-        "Multiplier for the pool token. Used to normalized token with different decimal into the same precision."
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "tokenAMultiplier",
-            "docs": ["Multiplier for token A of the pool."],
-            "type": "u64"
-          },
-          {
-            "name": "tokenBMultiplier",
-            "docs": ["Multiplier for token B of the pool."],
-            "type": "u64"
-          },
-          {
-            "name": "precisionFactor",
-            "docs": [
-              "Record the highest token decimal in the pool. For example, Token A is 6 decimal, token B is 9 decimal. This will save value of 9."
-            ],
-            "type": "u8"
-          }
-        ]
-      }
+      "discriminator": [
+        190,
+        106,
+        121,
+        6,
+        200,
+        182,
+        21,
+        75
+      ]
     },
     {
-      "name": "PoolFees",
-      "docs": ["Information regarding fee charges"],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "tradeFeeNumerator",
-            "docs": [
-              "Trade fees are extra token amounts that are held inside the token",
-              "accounts during a trade, making the value of liquidity tokens rise.",
-              "Trade fee numerator"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "tradeFeeDenominator",
-            "docs": ["Trade fee denominator"],
-            "type": "u64"
-          },
-          {
-            "name": "ownerTradeFeeNumerator",
-            "docs": [
-              "Owner trading fees are extra token amounts that are held inside the token",
-              "accounts during a trade, with the equivalent in pool tokens minted to",
-              "the owner of the program.",
-              "Owner trade fee numerator"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "ownerTradeFeeDenominator",
-            "docs": ["Owner trade fee denominator"],
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Depeg",
-      "docs": ["Contains information for depeg pool"],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "baseVirtualPrice",
-            "docs": ["The virtual price of staking / interest bearing token"],
-            "type": "u64"
-          },
-          {
-            "name": "baseCacheUpdated",
-            "docs": ["The virtual price of staking / interest bearing token"],
-            "type": "u64"
-          },
-          {
-            "name": "depegType",
-            "docs": ["Type of the depeg pool"],
-            "type": { "defined": "DepegType" }
-          }
-        ]
-      }
-    },
-    {
-      "name": "Padding",
-      "docs": ["Padding for future pool fields"],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "padding0",
-            "docs": ["Padding 0"],
-            "type": { "array": ["u8", 7] }
-          },
-          {
-            "name": "padding",
-            "docs": ["Padding 1"],
-            "type": { "array": ["u128", 29] }
-          }
-        ]
-      }
-    },
-    {
-      "name": "RoundDirection",
-      "docs": ["Rounding direction"],
-      "type": {
-        "kind": "enum",
-        "variants": [{ "name": "Floor" }, { "name": "Ceiling" }]
-      }
-    },
-    {
-      "name": "TradeDirection",
-      "docs": ["Trade (swap) direction"],
-      "type": {
-        "kind": "enum",
-        "variants": [{ "name": "AtoB" }, { "name": "BtoA" }]
-      }
-    },
-    {
-      "name": "NewCurveType",
-      "docs": ["Type of the swap curve"],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          { "name": "ConstantProduct" },
-          {
-            "name": "Stable",
-            "fields": [
-              {
-                "name": "amp",
-                "docs": ["Amplification coefficient"],
-                "type": "u64"
-              },
-              {
-                "name": "token_multiplier",
-                "docs": [
-                  "Multiplier for the pool token. Used to normalized token with different decimal into the same precision."
-                ],
-                "type": { "defined": "TokenMultiplier" }
-              },
-              {
-                "name": "depeg",
-                "docs": [
-                  "Depeg pool information. Contains functions to allow token amount to be repeg using stake / interest bearing token virtual price"
-                ],
-                "type": { "defined": "Depeg" }
-              },
-              {
-                "name": "last_amp_updated_timestamp",
-                "docs": [
-                  "The last amp updated timestamp. Used to prevent update_curve_info called infinitely many times within a short period"
-                ],
-                "type": "u64"
-              }
-            ]
-          },
-          {
-            "name": "NewCurve",
-            "fields": [
-              { "name": "field_one", "type": "u64" },
-              { "name": "field_two", "type": "u64" }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "CurveType",
-      "docs": ["Type of the swap curve"],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          { "name": "ConstantProduct" },
-          {
-            "name": "Stable",
-            "fields": [
-              {
-                "name": "amp",
-                "docs": ["Amplification coefficient"],
-                "type": "u64"
-              },
-              {
-                "name": "token_multiplier",
-                "docs": [
-                  "Multiplier for the pool token. Used to normalized token with different decimal into the same precision."
-                ],
-                "type": { "defined": "TokenMultiplier" }
-              },
-              {
-                "name": "depeg",
-                "docs": [
-                  "Depeg pool information. Contains functions to allow token amount to be repeg using stake / interest bearing token virtual price"
-                ],
-                "type": { "defined": "Depeg" }
-              },
-              {
-                "name": "last_amp_updated_timestamp",
-                "docs": [
-                  "The last amp updated timestamp. Used to prevent update_curve_info called infinitely many times within a short period"
-                ],
-                "type": "u64"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "DepegType",
-      "docs": ["Type of depeg pool"],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          { "name": "None" },
-          { "name": "Marinade" },
-          { "name": "Lido" },
-          { "name": "SplStake" }
-        ]
-      }
-    },
-    {
-      "name": "Rounding",
-      "docs": ["Round up, down"],
-      "type": {
-        "kind": "enum",
-        "variants": [{ "name": "Up" }, { "name": "Down" }]
-      }
-    },
-    {
-      "name": "PoolType",
-      "docs": ["Pool type"],
-      "type": {
-        "kind": "enum",
-        "variants": [{ "name": "Permissioned" }, { "name": "Permissionless" }]
-      }
+      "name": "Pool",
+      "discriminator": [
+        241,
+        154,
+        109,
+        4,
+        17,
+        177,
+        109,
+        188
+      ]
     }
   ],
   "events": [
     {
       "name": "AddLiquidity",
-      "fields": [
-        { "name": "lpMintAmount", "type": "u64", "index": false },
-        { "name": "tokenAAmount", "type": "u64", "index": false },
-        { "name": "tokenBAmount", "type": "u64", "index": false }
+      "discriminator": [
+        31,
+        94,
+        125,
+        90,
+        227,
+        52,
+        61,
+        186
       ]
     },
     {
       "name": "RemoveLiquidity",
-      "fields": [
-        { "name": "lpUnmintAmount", "type": "u64", "index": false },
-        { "name": "tokenAOutAmount", "type": "u64", "index": false },
-        { "name": "tokenBOutAmount", "type": "u64", "index": false }
+      "discriminator": [
+        116,
+        244,
+        97,
+        232,
+        103,
+        31,
+        152,
+        58
       ]
     },
     {
       "name": "BootstrapLiquidity",
-      "fields": [
-        { "name": "lpMintAmount", "type": "u64", "index": false },
-        { "name": "tokenAAmount", "type": "u64", "index": false },
-        { "name": "tokenBAmount", "type": "u64", "index": false },
-        { "name": "pool", "type": "publicKey", "index": false }
+      "discriminator": [
+        121,
+        127,
+        38,
+        136,
+        92,
+        55,
+        14,
+        247
       ]
     },
     {
       "name": "Swap",
-      "fields": [
-        { "name": "inAmount", "type": "u64", "index": false },
-        { "name": "outAmount", "type": "u64", "index": false },
-        { "name": "tradeFee", "type": "u64", "index": false },
-        { "name": "adminFee", "type": "u64", "index": false },
-        { "name": "hostFee", "type": "u64", "index": false }
+      "discriminator": [
+        81,
+        108,
+        227,
+        190,
+        205,
+        208,
+        10,
+        196
       ]
     },
     {
       "name": "SetPoolFees",
-      "fields": [
-        { "name": "tradeFeeNumerator", "type": "u64", "index": false },
-        { "name": "tradeFeeDenominator", "type": "u64", "index": false },
-        { "name": "ownerTradeFeeNumerator", "type": "u64", "index": false },
-        { "name": "ownerTradeFeeDenominator", "type": "u64", "index": false },
-        { "name": "pool", "type": "publicKey", "index": false }
+      "discriminator": [
+        245,
+        26,
+        198,
+        164,
+        88,
+        18,
+        75,
+        9
       ]
     },
     {
       "name": "PoolInfo",
-      "fields": [
-        { "name": "tokenAAmount", "type": "u64", "index": false },
-        { "name": "tokenBAmount", "type": "u64", "index": false },
-        { "name": "virtualPrice", "type": "f64", "index": false },
-        { "name": "currentTimestamp", "type": "u64", "index": false }
+      "discriminator": [
+        207,
+        20,
+        87,
+        97,
+        251,
+        212,
+        234,
+        45
       ]
     },
     {
       "name": "TransferAdmin",
-      "fields": [
-        { "name": "admin", "type": "publicKey", "index": false },
-        { "name": "newAdmin", "type": "publicKey", "index": false },
-        { "name": "pool", "type": "publicKey", "index": false }
-      ]
-    },
-    {
-      "name": "SetAdminFeeAccount",
-      "fields": [
-        { "name": "adminTokenAFee", "type": "publicKey", "index": false },
-        { "name": "adminTokenBFee", "type": "publicKey", "index": false },
-        { "name": "newAdminTokenAFee", "type": "publicKey", "index": false },
-        { "name": "newAdminTokenBFee", "type": "publicKey", "index": false }
+      "discriminator": [
+        228,
+        169,
+        131,
+        244,
+        61,
+        56,
+        65,
+        254
       ]
     },
     {
       "name": "OverrideCurveParam",
-      "fields": [
-        { "name": "newAmp", "type": "u64", "index": false },
-        { "name": "updatedTimestamp", "type": "u64", "index": false },
-        { "name": "pool", "type": "publicKey", "index": false }
+      "discriminator": [
+        247,
+        20,
+        165,
+        248,
+        75,
+        5,
+        54,
+        246
       ]
     },
     {
       "name": "PoolCreated",
-      "fields": [
-        { "name": "lpMint", "type": "publicKey", "index": false },
-        { "name": "tokenAMint", "type": "publicKey", "index": false },
-        { "name": "tokenBMint", "type": "publicKey", "index": false },
-        {
-          "name": "poolType",
-          "type": { "defined": "PoolType" },
-          "index": false
-        },
-        { "name": "pool", "type": "publicKey", "index": false }
+      "discriminator": [
+        202,
+        44,
+        41,
+        88,
+        104,
+        220,
+        157,
+        82
       ]
     },
     {
       "name": "PoolEnabled",
-      "fields": [
-        { "name": "pool", "type": "publicKey", "index": false },
-        { "name": "enabled", "type": "bool", "index": false }
+      "discriminator": [
+        2,
+        151,
+        18,
+        83,
+        204,
+        134,
+        92,
+        191
       ]
     },
     {
       "name": "MigrateFeeAccount",
-      "fields": [
-        { "name": "pool", "type": "publicKey", "index": false },
-        { "name": "newAdminTokenAFee", "type": "publicKey", "index": false },
-        { "name": "newAdminTokenBFee", "type": "publicKey", "index": false },
-        { "name": "tokenAAmount", "type": "u64", "index": false },
-        { "name": "tokenBAmount", "type": "u64", "index": false }
+      "discriminator": [
+        223,
+        234,
+        232,
+        26,
+        252,
+        105,
+        180,
+        125
       ]
     },
     {
       "name": "CreateLockEscrow",
-      "fields": [
-        { "name": "pool", "type": "publicKey", "index": false },
-        { "name": "owner", "type": "publicKey", "index": false }
+      "discriminator": [
+        74,
+        94,
+        106,
+        141,
+        49,
+        17,
+        98,
+        109
       ]
     },
     {
       "name": "Lock",
-      "fields": [
-        { "name": "pool", "type": "publicKey", "index": false },
-        { "name": "owner", "type": "publicKey", "index": false },
-        { "name": "amount", "type": "u64", "index": false }
+      "discriminator": [
+        220,
+        183,
+        67,
+        215,
+        153,
+        207,
+        56,
+        234
       ]
     },
     {
       "name": "ClaimFee",
-      "fields": [
-        { "name": "pool", "type": "publicKey", "index": false },
-        { "name": "owner", "type": "publicKey", "index": false },
-        { "name": "amount", "type": "u64", "index": false },
-        { "name": "aFee", "type": "u64", "index": false },
-        { "name": "bFee", "type": "u64", "index": false }
+      "discriminator": [
+        75,
+        122,
+        154,
+        48,
+        140,
+        74,
+        123,
+        163
+      ]
+    },
+    {
+      "name": "CreateConfig",
+      "discriminator": [
+        199,
+        152,
+        10,
+        19,
+        39,
+        39,
+        157,
+        104
+      ]
+    },
+    {
+      "name": "CloseConfig",
+      "discriminator": [
+        249,
+        181,
+        108,
+        89,
+        4,
+        150,
+        90,
+        174
+      ]
+    },
+    {
+      "name": "WithdrawProtocolFees",
+      "discriminator": [
+        30,
+        240,
+        207,
+        196,
+        139,
+        239,
+        79,
+        28
+      ]
+    },
+    {
+      "name": "PartnerClaimFees",
+      "discriminator": [
+        135,
+        131,
+        10,
+        94,
+        119,
+        209,
+        202,
+        48
       ]
     }
   ],
   "errors": [
-    { "code": 6000, "name": "MathOverflow", "msg": "Math operation overflow" },
-    { "code": 6001, "name": "InvalidFee", "msg": "Invalid fee setup" },
-    { "code": 6002, "name": "InvalidInvariant", "msg": "Invalid invariant d" },
+    {
+      "code": 6000,
+      "name": "MathOverflow",
+      "msg": "Math operation overflow"
+    },
+    {
+      "code": 6001,
+      "name": "InvalidFee",
+      "msg": "Invalid fee setup"
+    },
+    {
+      "code": 6002,
+      "name": "InvalidInvariant",
+      "msg": "Invalid invariant d"
+    },
     {
       "code": 6003,
       "name": "FeeCalculationFailure",
@@ -2352,7 +3141,11 @@
       "name": "MismatchedTokenMint",
       "msg": "Token mint mismatched"
     },
-    { "code": 6010, "name": "MismatchedLpMint", "msg": "LP mint mismatched" },
+    {
+      "code": 6010,
+      "name": "MismatchedLpMint",
+      "msg": "LP mint mismatched"
+    },
     {
       "code": 6011,
       "name": "MismatchedOwner",
@@ -2373,7 +3166,11 @@
       "name": "InvalidPoolLpMintAccount",
       "msg": "Invalid pool lp mint account"
     },
-    { "code": 6015, "name": "PoolDisabled", "msg": "Pool disabled" },
+    {
+      "code": 6015,
+      "name": "PoolDisabled",
+      "msg": "Pool disabled"
+    },
     {
       "code": 6016,
       "name": "InvalidAdminAccount",
@@ -2381,10 +3178,14 @@
     },
     {
       "code": 6017,
-      "name": "InvalidAdminFeeAccount",
-      "msg": "Invalid admin fee account"
+      "name": "InvalidProtocolFeeAccount",
+      "msg": "Invalid protocol fee account"
     },
-    { "code": 6018, "name": "SameAdminAccount", "msg": "Same admin account" },
+    {
+      "code": 6018,
+      "name": "SameAdminAccount",
+      "msg": "Same admin account"
+    },
     {
       "code": 6019,
       "name": "IdenticalSourceDestination",
@@ -2440,7 +3241,11 @@
       "name": "MismatchedDepegMint",
       "msg": "Token mint B doesn't matches depeg type token mint"
     },
-    { "code": 6030, "name": "InvalidApyAccount", "msg": "Invalid APY account" },
+    {
+      "code": 6030,
+      "name": "InvalidApyAccount",
+      "msg": "Invalid APY account"
+    },
     {
       "code": 6031,
       "name": "InvalidTokenMultiplier",
@@ -2456,28 +3261,1356 @@
       "name": "UpdateTimeConstraint",
       "msg": "Update time constraint violated"
     },
-    { "code": 6034, "name": "ExceedMaxFeeBps", "msg": "Exceeded max fee bps" },
+    {
+      "code": 6034,
+      "name": "ExceedMaxFeeBps",
+      "msg": "Exceeded max fee bps"
+    },
     {
       "code": 6035,
-      "name": "OwnerFeeOverHalfOfTradeFee",
-      "msg": "Owner fee exceed half of trade fee"
+      "name": "InvalidAdmin",
+      "msg": "Invalid admin"
     },
-    { "code": 6036, "name": "InvalidAdmin", "msg": "Invalid admin" },
     {
-      "code": 6037,
+      "code": 6036,
       "name": "PoolIsNotPermissioned",
       "msg": "Pool is not permissioned"
     },
     {
-      "code": 6038,
+      "code": 6037,
       "name": "InvalidDepositAmount",
       "msg": "Invalid deposit amount"
     },
-    { "code": 6039, "name": "InvalidFeeOwner", "msg": "Invalid fee owner" },
-    { "code": 6040, "name": "NonDepletedPool", "msg": "Pool is not depleted" },
-    { "code": 6041, "name": "AmountNotPeg", "msg": "Token amount is not 1:1" },
-    { "code": 6042, "name": "AmountIsZero", "msg": "Amount is zero" },
-    { "code": 6043, "name": "TypeCastFailed", "msg": "Type cast error" },
-    { "code": 6044, "name": "AmountIsNotEnough", "msg": "Amount is not enough" }
+    {
+      "code": 6038,
+      "name": "InvalidFeeOwner",
+      "msg": "Invalid fee owner"
+    },
+    {
+      "code": 6039,
+      "name": "NonDepletedPool",
+      "msg": "Pool is not depleted"
+    },
+    {
+      "code": 6040,
+      "name": "AmountNotPeg",
+      "msg": "Token amount is not 1:1"
+    },
+    {
+      "code": 6041,
+      "name": "AmountIsZero",
+      "msg": "Amount is zero"
+    },
+    {
+      "code": 6042,
+      "name": "TypeCastFailed",
+      "msg": "Type cast error"
+    },
+    {
+      "code": 6043,
+      "name": "AmountIsNotEnough",
+      "msg": "Amount is not enough"
+    },
+    {
+      "code": 6044,
+      "name": "InvalidActivationDuration",
+      "msg": "Invalid activation duration"
+    },
+    {
+      "code": 6045,
+      "name": "PoolIsNotLaunchPool",
+      "msg": "Pool is not launch pool"
+    },
+    {
+      "code": 6046,
+      "name": "UnableToModifyActivationPoint",
+      "msg": "Unable to modify activation point"
+    },
+    {
+      "code": 6047,
+      "name": "InvalidAuthorityToCreateThePool",
+      "msg": "Invalid authority to create the pool"
+    },
+    {
+      "code": 6048,
+      "name": "InvalidActivationType",
+      "msg": "Invalid activation type"
+    },
+    {
+      "code": 6049,
+      "name": "InvalidActivationPoint",
+      "msg": "Invalid activation point"
+    },
+    {
+      "code": 6050,
+      "name": "PreActivationSwapStarted",
+      "msg": "Pre activation swap window started"
+    },
+    {
+      "code": 6051,
+      "name": "InvalidPoolType",
+      "msg": "Invalid pool type"
+    },
+    {
+      "code": 6052,
+      "name": "InvalidQuoteMint",
+      "msg": "Quote token must be SOL,USDC"
+    }
+  ],
+  "types": [
+    {
+      "name": "TokenMultiplier",
+      "docs": [
+        "Multiplier for the pool token. Used to normalized token with different decimal into the same precision."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "token_a_multiplier",
+            "docs": [
+              "Multiplier for token A of the pool."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "token_b_multiplier",
+            "docs": [
+              "Multiplier for token B of the pool."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "precision_factor",
+            "docs": [
+              "Record the highest token decimal in the pool. For example, Token A is 6 decimal, token B is 9 decimal. This will save value of 9."
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolFees",
+      "docs": [
+        "Information regarding fee charges"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "trade_fee_numerator",
+            "docs": [
+              "Trade fees are extra token amounts that are held inside the token",
+              "accounts during a trade, making the value of liquidity tokens rise.",
+              "Trade fee numerator"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "trade_fee_denominator",
+            "docs": [
+              "Trade fee denominator"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_numerator",
+            "docs": [
+              "Protocol trading fees are extra token amounts that are held inside the token",
+              "accounts during a trade, with the equivalent in pool tokens minted to",
+              "the protocol of the program.",
+              "Protocol trade fee numerator"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_denominator",
+            "docs": [
+              "Protocol trade fee denominator"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Depeg",
+      "docs": [
+        "Contains information for depeg pool"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "base_virtual_price",
+            "docs": [
+              "The virtual price of staking / interest bearing token"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "base_cache_updated",
+            "docs": [
+              "The last time base_virtual_price is updated"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "depeg_type",
+            "docs": [
+              "Type of the depeg pool"
+            ],
+            "type": {
+              "defined": {
+                "name": "DepegType"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConfigParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "activation_duration",
+            "type": "u64"
+          },
+          {
+            "name": "vault_config_key",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_creator_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "activation_type",
+            "type": "u8"
+          },
+          {
+            "name": "index",
+            "type": "u64"
+          },
+          {
+            "name": "partner_fee_numerator",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CustomizableParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "trade_fee_numerator",
+            "docs": [
+              "Trading fee."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "activation_point",
+            "docs": [
+              "The pool start trading."
+            ],
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "has_alpha_vault",
+            "docs": [
+              "Whether the pool support alpha vault"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "activation_type",
+            "docs": [
+              "Activation type"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "Padding"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                90
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Padding",
+      "docs": [
+        "Padding for future pool fields"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "padding0",
+            "docs": [
+              "Padding 0"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          },
+          {
+            "name": "padding1",
+            "docs": [
+              "Padding 1"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                21
+              ]
+            }
+          },
+          {
+            "name": "padding2",
+            "docs": [
+              "Padding 2"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                21
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PartnerInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "partner_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "pending_fee_a",
+            "type": "u64"
+          },
+          {
+            "name": "pending_fee_b",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Bootstrapping",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "activation_point",
+            "docs": [
+              "Activation point, can be slot or timestamp"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "whitelisted_vault",
+            "docs": [
+              "Whitelisted vault to be able to buy pool before activation_point"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_creator",
+            "docs": [
+              "Need to store pool creator in lauch pool, so they can modify liquidity before activation_point"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "activation_type",
+            "docs": [
+              "Activation type, 0 means by slot, 1 means by timestamp"
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ActivationType",
+      "docs": [
+        "Type of the activation"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Slot"
+          },
+          {
+            "name": "Timestamp"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RoundDirection",
+      "docs": [
+        "Rounding direction"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Floor"
+          },
+          {
+            "name": "Ceiling"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TradeDirection",
+      "docs": [
+        "Trade (swap) direction"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "AtoB"
+          },
+          {
+            "name": "BtoA"
+          }
+        ]
+      }
+    },
+    {
+      "name": "NewCurveType",
+      "docs": [
+        "Type of the swap curve"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "ConstantProduct"
+          },
+          {
+            "name": "Stable",
+            "fields": [
+              {
+                "name": "amp",
+                "docs": [
+                  "Amplification coefficient"
+                ],
+                "type": "u64"
+              },
+              {
+                "name": "token_multiplier",
+                "docs": [
+                  "Multiplier for the pool token. Used to normalized token with different decimal into the same precision."
+                ],
+                "type": {
+                  "defined": {
+                    "name": "TokenMultiplier"
+                  }
+                }
+              },
+              {
+                "name": "depeg",
+                "docs": [
+                  "Depeg pool information. Contains functions to allow token amount to be repeg using stake / interest bearing token virtual price"
+                ],
+                "type": {
+                  "defined": {
+                    "name": "Depeg"
+                  }
+                }
+              },
+              {
+                "name": "last_amp_updated_timestamp",
+                "docs": [
+                  "The last amp updated timestamp. Used to prevent update_curve_info called infinitely many times within a short period"
+                ],
+                "type": "u64"
+              }
+            ]
+          },
+          {
+            "name": "NewCurve",
+            "fields": [
+              {
+                "name": "field_one",
+                "type": "u64"
+              },
+              {
+                "name": "field_two",
+                "type": "u64"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "CurveType",
+      "docs": [
+        "Type of the swap curve"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "ConstantProduct"
+          },
+          {
+            "name": "Stable",
+            "fields": [
+              {
+                "name": "amp",
+                "docs": [
+                  "Amplification coefficient"
+                ],
+                "type": "u64"
+              },
+              {
+                "name": "token_multiplier",
+                "docs": [
+                  "Multiplier for the pool token. Used to normalized token with different decimal into the same precision."
+                ],
+                "type": {
+                  "defined": {
+                    "name": "TokenMultiplier"
+                  }
+                }
+              },
+              {
+                "name": "depeg",
+                "docs": [
+                  "Depeg pool information. Contains functions to allow token amount to be repeg using stake / interest bearing token virtual price"
+                ],
+                "type": {
+                  "defined": {
+                    "name": "Depeg"
+                  }
+                }
+              },
+              {
+                "name": "last_amp_updated_timestamp",
+                "docs": [
+                  "The last amp updated timestamp. Used to prevent update_curve_info called infinitely many times within a short period"
+                ],
+                "type": "u64"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "DepegType",
+      "docs": [
+        "Type of depeg pool"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "None"
+          },
+          {
+            "name": "Marinade"
+          },
+          {
+            "name": "Lido"
+          },
+          {
+            "name": "SplStake"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Rounding",
+      "docs": [
+        "Round up, down"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Up"
+          },
+          {
+            "name": "Down"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolType",
+      "docs": [
+        "Pool type"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Permissioned"
+          },
+          {
+            "name": "Permissionless"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Config",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_fees",
+            "type": {
+              "defined": {
+                "name": "PoolFees"
+              }
+            }
+          },
+          {
+            "name": "activation_duration",
+            "type": "u64"
+          },
+          {
+            "name": "vault_config_key",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_creator_authority",
+            "docs": [
+              "Only pool_creator_authority can use the current config to initialize new pool. When it's Pubkey::default, it's a public config."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "activation_type",
+            "docs": [
+              "Activation type"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "partner_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                219
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LockEscrow",
+      "docs": [
+        "State of lock escrow account"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "docs": [
+              "Pool address"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "docs": [
+              "Owner address"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "escrow_vault",
+            "docs": [
+              "Vault address, store the lock user lock"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "bump, used to sign"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "total_locked_amount",
+            "docs": [
+              "Total locked amount"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lp_per_token",
+            "docs": [
+              "Lp per token, virtual price of lp token"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "unclaimed_fee_pending",
+            "docs": [
+              "Unclaimed fee pending"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "a_fee",
+            "docs": [
+              "Total a fee claimed so far"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "b_fee",
+            "docs": [
+              "Total b fee claimed so far"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Pool",
+      "docs": [
+        "State of pool account"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lp_mint",
+            "docs": [
+              "LP token mint of the pool"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_a_mint",
+            "docs": [
+              "Token A mint of the pool. Eg: USDT"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_b_mint",
+            "docs": [
+              "Token B mint of the pool. Eg: USDC"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "a_vault",
+            "docs": [
+              "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "b_vault",
+            "docs": [
+              "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "a_vault_lp",
+            "docs": [
+              "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "b_vault_lp",
+            "docs": [
+              "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "a_vault_lp_bump",
+            "docs": [
+              "\"A\" vault lp bump. Used to create signer seeds."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "enabled",
+            "docs": [
+              "Flag to determine whether the pool is enabled, or disabled."
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "protocol_token_a_fee",
+            "docs": [
+              "Protocol fee token account for token A. Used to receive trading fee."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "protocol_token_b_fee",
+            "docs": [
+              "Protocol fee token account for token B. Used to receive trading fee."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_last_updated_at",
+            "docs": [
+              "Fee last updated timestamp"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "padding0",
+            "type": {
+              "array": [
+                "u8",
+                24
+              ]
+            }
+          },
+          {
+            "name": "fees",
+            "docs": [
+              "Store the fee charges setting."
+            ],
+            "type": {
+              "defined": {
+                "name": "PoolFees"
+              }
+            }
+          },
+          {
+            "name": "pool_type",
+            "docs": [
+              "Pool type"
+            ],
+            "type": {
+              "defined": {
+                "name": "PoolType"
+              }
+            }
+          },
+          {
+            "name": "stake",
+            "docs": [
+              "Stake pubkey of SPL stake pool"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "total_locked_lp",
+            "docs": [
+              "Total locked lp token"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "bootstrapping",
+            "docs": [
+              "bootstrapping config"
+            ],
+            "type": {
+              "defined": {
+                "name": "Bootstrapping"
+              }
+            }
+          },
+          {
+            "name": "partner_info",
+            "type": {
+              "defined": {
+                "name": "PartnerInfo"
+              }
+            }
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "Padding for future pool field"
+            ],
+            "type": {
+              "defined": {
+                "name": "Padding"
+              }
+            }
+          },
+          {
+            "name": "curve_type",
+            "docs": [
+              "The type of the swap curve supported by the pool."
+            ],
+            "type": {
+              "defined": {
+                "name": "CurveType"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "AddLiquidity",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lp_mint_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_a_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RemoveLiquidity",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lp_unmint_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_a_out_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_b_out_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BootstrapLiquidity",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lp_mint_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_a_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount",
+            "type": "u64"
+          },
+          {
+            "name": "pool",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Swap",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "in_amount",
+            "type": "u64"
+          },
+          {
+            "name": "out_amount",
+            "type": "u64"
+          },
+          {
+            "name": "trade_fee",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fee",
+            "type": "u64"
+          },
+          {
+            "name": "host_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SetPoolFees",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "trade_fee_denominator",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_denominator",
+            "type": "u64"
+          },
+          {
+            "name": "pool",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "token_a_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount",
+            "type": "u64"
+          },
+          {
+            "name": "virtual_price",
+            "type": "f64"
+          },
+          {
+            "name": "current_timestamp",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TransferAdmin",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "admin",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_admin",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OverrideCurveParam",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "new_amp",
+            "type": "u64"
+          },
+          {
+            "name": "updated_timestamp",
+            "type": "u64"
+          },
+          {
+            "name": "pool",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolCreated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lp_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_a_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_b_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_type",
+            "type": {
+              "defined": {
+                "name": "PoolType"
+              }
+            }
+          },
+          {
+            "name": "pool",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolEnabled",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "enabled",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MigrateFeeAccount",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_admin_token_a_fee",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_admin_token_b_fee",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_a_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreateLockEscrow",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Lock",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ClaimFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "a_fee",
+            "type": "u64"
+          },
+          {
+            "name": "b_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreateConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CloseConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "config",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawProtocolFees",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "protocol_a_fee",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_b_fee",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_a_fee_owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "protocol_b_fee_owner",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PartnerClaimFees",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_a",
+            "type": "u64"
+          },
+          {
+            "name": "fee_b",
+            "type": "u64"
+          },
+          {
+            "name": "partner",
+            "type": "pubkey"
+          }
+        ]
+      }
+    }
   ]
 }

--- a/idl/meteora_damm_v2.json
+++ b/idl/meteora_damm_v2.json
@@ -2,7 +2,7 @@
   "address": "cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG",
   "metadata": {
     "name": "cp_amm",
-    "version": "0.1.7",
+    "version": "0.2.2",
     "spec": "0.1.0",
     "description": "Created with Anchor"
   },
@@ -90,9 +90,9 @@
           ]
         },
         {
-          "name": "owner",
+          "name": "signer",
           "docs": [
-            "owner of position"
+            "Signer"
           ],
           "signer": true
         },
@@ -109,33 +109,7 @@
           ]
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -149,142 +123,6 @@
               "name": "AddLiquidityParameters"
             }
           }
-        }
-      ]
-    },
-    {
-      "name": "claim_partner_fee",
-      "discriminator": [
-        97,
-        206,
-        39,
-        105,
-        94,
-        94,
-        126,
-        148
-      ],
-      "accounts": [
-        {
-          "name": "pool_authority",
-          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
-        },
-        {
-          "name": "pool",
-          "writable": true
-        },
-        {
-          "name": "token_a_account",
-          "docs": [
-            "The treasury token a account"
-          ],
-          "writable": true
-        },
-        {
-          "name": "token_b_account",
-          "docs": [
-            "The treasury token b account"
-          ],
-          "writable": true
-        },
-        {
-          "name": "token_a_vault",
-          "docs": [
-            "The vault token account for input token"
-          ],
-          "writable": true,
-          "relations": [
-            "pool"
-          ]
-        },
-        {
-          "name": "token_b_vault",
-          "docs": [
-            "The vault token account for output token"
-          ],
-          "writable": true,
-          "relations": [
-            "pool"
-          ]
-        },
-        {
-          "name": "token_a_mint",
-          "docs": [
-            "The mint of token a"
-          ],
-          "relations": [
-            "pool"
-          ]
-        },
-        {
-          "name": "token_b_mint",
-          "docs": [
-            "The mint of token b"
-          ],
-          "relations": [
-            "pool"
-          ]
-        },
-        {
-          "name": "partner",
-          "signer": true,
-          "relations": [
-            "pool"
-          ]
-        },
-        {
-          "name": "token_a_program",
-          "docs": [
-            "Token a program"
-          ]
-        },
-        {
-          "name": "token_b_program",
-          "docs": [
-            "Token b program"
-          ]
-        },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "name": "program"
-        }
-      ],
-      "args": [
-        {
-          "name": "max_amount_a",
-          "type": "u64"
-        },
-        {
-          "name": "max_amount_b",
-          "type": "u64"
         }
       ]
     },
@@ -374,9 +212,9 @@
           ]
         },
         {
-          "name": "owner",
+          "name": "signer",
           "docs": [
-            "owner of position"
+            "Signer"
           ],
           "signer": true
         },
@@ -393,33 +231,7 @@
           ]
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -520,33 +332,7 @@
           ]
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -559,6 +345,79 @@
         },
         {
           "name": "max_amount_b",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "claim_protocol_fee2",
+      "discriminator": [
+        235,
+        194,
+        54,
+        69,
+        65,
+        10,
+        236,
+        112
+      ],
+      "accounts": [
+        {
+          "name": "receiver_token_account",
+          "docs": [
+            "receiver token account for the claimed token. validated through the protocol_fee program"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_a_mint",
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "token_b_mint",
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "token_a_program"
+        },
+        {
+          "name": "token_b_program"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "token_a_vault",
+          "writable": true,
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "token_b_vault",
+          "writable": true,
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "signer",
+          "signer": true,
+          "address": "FkU5rQCWQM131skHCpcEbK8P1JrQGsBgqXe55w525SSF"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount",
           "type": "u64"
         }
       ]
@@ -612,9 +471,9 @@
           ]
         },
         {
-          "name": "owner",
+          "name": "signer",
           "docs": [
-            "owner of position"
+            "Signer"
           ],
           "signer": true
         },
@@ -622,33 +481,7 @@
           "name": "token_program"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -694,33 +527,7 @@
           "writable": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -754,33 +561,7 @@
           "writable": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -849,33 +630,7 @@
           "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -912,33 +667,7 @@
           "writable": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -1002,33 +731,7 @@
           "address": "11111111111111111111111111111111"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -1102,33 +805,7 @@
           "address": "11111111111111111111111111111111"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -1207,33 +884,7 @@
           "address": "11111111111111111111111111111111"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -1363,33 +1014,7 @@
           "address": "11111111111111111111111111111111"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -1458,33 +1083,7 @@
           "address": "11111111111111111111111111111111"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -1527,6 +1126,105 @@
       ]
     },
     {
+      "name": "fix_config_fee_params",
+      "discriminator": [
+        38,
+        30,
+        216,
+        81,
+        250,
+        177,
+        243,
+        254
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "BaseFeeParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "fix_pool_fee_params",
+      "discriminator": [
+        132,
+        98,
+        81,
+        196,
+        44,
+        58,
+        120,
+        193
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "BaseFeeParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "fix_pool_layout_version",
+      "discriminator": [
+        166,
+        158,
+        69,
+        35,
+        81,
+        167,
+        200,
+        215
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "fund_reward",
       "discriminator": [
         188,
@@ -1562,33 +1260,7 @@
           "name": "token_program"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -1837,33 +1509,7 @@
           "address": "11111111111111111111111111111111"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -2117,33 +1763,7 @@
           "address": "11111111111111111111111111111111"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -2401,33 +2021,7 @@
           "address": "11111111111111111111111111111111"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -2518,33 +2112,7 @@
           "address": "11111111111111111111111111111111"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -2562,6 +2130,60 @@
         {
           "name": "funder",
           "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "lock_inner_position",
+      "discriminator": [
+        72,
+        19,
+        49,
+        204,
+        18,
+        122,
+        23,
+        90
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "The token account for nft"
+          ]
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Signer"
+          ],
+          "signer": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "VestingParameters"
+            }
+          }
         }
       ]
     },
@@ -2600,9 +2222,9 @@
           ]
         },
         {
-          "name": "owner",
+          "name": "signer",
           "docs": [
-            "owner of position"
+            "Signer"
           ],
           "signer": true
         },
@@ -2616,33 +2238,7 @@
           "address": "11111111111111111111111111111111"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -2690,40 +2286,14 @@
           ]
         },
         {
-          "name": "owner",
+          "name": "signer",
           "docs": [
-            "owner of position"
+            "Signer"
           ],
           "signer": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -2858,9 +2428,9 @@
           ]
         },
         {
-          "name": "owner",
+          "name": "signer",
           "docs": [
-            "owner of position"
+            "Signer"
           ],
           "signer": true
         },
@@ -2877,33 +2447,7 @@
           ]
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -3007,9 +2551,9 @@
           ]
         },
         {
-          "name": "owner",
+          "name": "signer",
           "docs": [
-            "owner of position"
+            "Signer"
           ],
           "signer": true
         },
@@ -3026,33 +2570,7 @@
           ]
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -3094,33 +2612,7 @@
           "signer": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -3195,33 +2687,7 @@
           "signer": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -3300,33 +2766,7 @@
           "signer": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -3437,33 +2877,7 @@
           "optional": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -3578,33 +2992,7 @@
           "optional": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -3618,6 +3006,47 @@
               "name": "SwapParameters2"
             }
           }
+        }
+      ]
+    },
+    {
+      "name": "update_delegate_permission",
+      "discriminator": [
+        175,
+        165,
+        56,
+        64,
+        0,
+        251,
+        89,
+        47
+      ],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "The token account for nft"
+          ]
+        },
+        {
+          "name": "owner",
+          "signer": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "permission",
+          "type": "u32"
         }
       ]
     },
@@ -3646,33 +3075,7 @@
           "signer": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -3711,33 +3114,7 @@
           "signer": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -3776,33 +3153,7 @@
           "signer": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -3816,6 +3167,59 @@
         {
           "name": "new_funder",
           "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "withdraw_dead_liquidity_reward",
+      "discriminator": [
+        121,
+        99,
+        224,
+        91,
+        178,
+        14,
+        22,
+        132
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "reward_vault",
+          "writable": true
+        },
+        {
+          "name": "reward_mint"
+        },
+        {
+          "name": "funder_token_account",
+          "writable": true
+        },
+        {
+          "name": "funder",
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u8"
         }
       ]
     },
@@ -3859,33 +3263,7 @@
           "name": "token_program"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -4083,19 +3461,6 @@
   ],
   "events": [
     {
-      "name": "EvtClaimPartnerFee",
-      "discriminator": [
-        118,
-        99,
-        77,
-        10,
-        226,
-        1,
-        1,
-        87
-      ]
-    },
-    {
       "name": "EvtClaimPositionFee",
       "discriminator": [
         198,
@@ -4119,6 +3484,19 @@
         13,
         25,
         33
+      ]
+    },
+    {
+      "name": "EvtClaimProtocolFee2",
+      "discriminator": [
+        187,
+        133,
+        66,
+        9,
+        205,
+        161,
+        84,
+        13
       ]
     },
     {
@@ -4317,6 +3695,19 @@
       ]
     },
     {
+      "name": "EvtSplitPosition3",
+      "discriminator": [
+        232,
+        117,
+        190,
+        218,
+        85,
+        162,
+        207,
+        78
+      ]
+    },
+    {
       "name": "EvtSwap2",
       "discriminator": [
         189,
@@ -4327,6 +3718,19 @@
         80,
         117,
         153
+      ]
+    },
+    {
+      "name": "EvtUpdateDelegatePermission",
+      "discriminator": [
+        66,
+        188,
+        75,
+        151,
+        150,
+        232,
+        87,
+        93
       ]
     },
     {
@@ -4366,6 +3770,19 @@
         115,
         246,
         146
+      ]
+    },
+    {
+      "name": "EvtWithdrawDeadLiquidityReward",
+      "discriminator": [
+        228,
+        66,
+        150,
+        195,
+        42,
+        62,
+        163,
+        13
       ]
     },
     {
@@ -4717,6 +4134,26 @@
       "code": 6066,
       "name": "InvalidZapAccounts",
       "msg": "Invalid zap accounts"
+    },
+    {
+      "code": 6067,
+      "name": "InvalidCompoundingFeeBps",
+      "msg": "Invalid compounding fee bps"
+    },
+    {
+      "code": 6068,
+      "name": "InvalidClaimProtocolFeeAccounts",
+      "msg": "Invalid claim protocol fee accounts"
+    },
+    {
+      "code": 6069,
+      "name": "TransferFeeExcludedAmountIsZero",
+      "msg": "Transfer fee excluded amount is zero"
+    },
+    {
+      "code": 6070,
+      "name": "DelegatedAmountNonZero",
+      "msg": "Delegated amount is not zero"
     }
   ],
   "types": [
@@ -4780,7 +4217,7 @@
             "type": {
               "array": [
                 "u8",
-                30
+                27
               ]
             }
           }
@@ -4839,15 +4276,6 @@
           {
             "name": "base_fee_mode",
             "type": "u8"
-          },
-          {
-            "name": "padding",
-            "type": {
-              "array": [
-                "u8",
-                3
-              ]
-            }
           }
         ]
       }
@@ -4893,15 +4321,6 @@
           {
             "name": "base_fee_mode",
             "type": "u8"
-          },
-          {
-            "name": "padding",
-            "type": {
-              "array": [
-                "u8",
-                3
-              ]
-            }
           }
         ]
       }
@@ -4930,15 +4349,6 @@
           {
             "name": "base_fee_mode",
             "type": "u8"
-          },
-          {
-            "name": "padding",
-            "type": {
-              "array": [
-                "u8",
-                3
-              ]
-            }
           }
         ]
       }
@@ -5259,26 +4669,6 @@
       }
     },
     {
-      "name": "EvtClaimPartnerFee",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "pool",
-            "type": "pubkey"
-          },
-          {
-            "name": "token_a_amount",
-            "type": "u64"
-          },
-          {
-            "name": "token_b_amount",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
       "name": "EvtClaimPositionFee",
       "type": {
         "kind": "struct",
@@ -5321,6 +4711,30 @@
           },
           {
             "name": "token_b_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtClaimProtocolFee2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "receiver_token_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
             "type": "u64"
           }
         ]
@@ -5901,6 +5315,70 @@
       }
     },
     {
+      "name": "EvtSplitPosition3",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "first_owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "second_owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "first_position",
+            "type": "pubkey"
+          },
+          {
+            "name": "second_position",
+            "type": "pubkey"
+          },
+          {
+            "name": "current_sqrt_price",
+            "type": "u128"
+          },
+          {
+            "name": "amount_splits",
+            "type": {
+              "defined": {
+                "name": "SplitAmountInfo2"
+              }
+            }
+          },
+          {
+            "name": "first_position_info",
+            "type": {
+              "defined": {
+                "name": "SplitPositionInfo2"
+              }
+            }
+          },
+          {
+            "name": "second_position_info",
+            "type": {
+              "defined": {
+                "name": "SplitPositionInfo2"
+              }
+            }
+          },
+          {
+            "name": "split_position_parameters",
+            "type": {
+              "defined": {
+                "name": "SplitPositionParameters3"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
       "name": "EvtSwap2",
       "type": {
         "kind": "struct",
@@ -5960,6 +5438,32 @@
           {
             "name": "reserve_b_amount",
             "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtUpdateDelegatePermission",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "permission",
+            "type": "u32"
+          },
+          {
+            "name": "delegate",
+            "type": {
+              "option": "pubkey"
+            }
           }
         ]
       }
@@ -6032,6 +5536,26 @@
           {
             "name": "new_funder",
             "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtWithdrawDeadLiquidityReward",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
           }
         ]
       }
@@ -6159,6 +5683,51 @@
             ],
             "type": {
               "option": "u64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "InnerVesting",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "cliff_point",
+            "type": "u64"
+          },
+          {
+            "name": "period_frequency",
+            "type": "u64"
+          },
+          {
+            "name": "cliff_unlock_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "liquidity_per_period",
+            "type": "u128"
+          },
+          {
+            "name": "total_released_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "number_of_period",
+            "type": "u16"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                14
+              ]
             }
           }
         ]
@@ -6380,11 +5949,16 @@
             "type": "pubkey"
           },
           {
-            "name": "partner",
+            "name": "padding_0",
             "docs": [
-              "partner"
+              "padding, previously partner pubkey, be careful when using this field"
             ],
-            "type": "pubkey"
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
           },
           {
             "name": "liquidity",
@@ -6394,7 +5968,7 @@
             "type": "u128"
           },
           {
-            "name": "_padding",
+            "name": "padding_1",
             "docs": [
               "padding, previous reserve amount, be careful to use that field"
             ],
@@ -6415,18 +5989,8 @@
             "type": "u64"
           },
           {
-            "name": "partner_a_fee",
-            "docs": [
-              "partner a fee"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "partner_b_fee",
-            "docs": [
-              "partner b fee"
-            ],
-            "type": "u64"
+            "name": "padding_2",
+            "type": "u128"
           },
           {
             "name": "sqrt_min_price",
@@ -6499,14 +6063,14 @@
             "type": "u8"
           },
           {
-            "name": "version",
+            "name": "fee_version",
             "docs": [
-              "pool version, 0: max_fee is still capped at 50%, 1: max_fee is capped at 99%"
+              "pool fee version, 0: max_fee is still capped at 50%, 1: max_fee is capped at 99%"
             ],
             "type": "u8"
           },
           {
-            "name": "_padding_0",
+            "name": "padding_3",
             "docs": [
               "padding"
             ],
@@ -6559,14 +6123,47 @@
             "type": "pubkey"
           },
           {
-            "name": "_padding_1",
+            "name": "token_a_amount",
+            "docs": [
+              "token a amount"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount",
+            "docs": [
+              "token b amount"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "layout_version",
+            "docs": [
+              "layout version: version 0: haven't track token_a_amount and token_b_amount, version 1: track token_a_amount and token_b_amount"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding_4",
+            "docs": [
+              "Padding for further use"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                7
+              ]
+            }
+          },
+          {
+            "name": "padding_5",
             "docs": [
               "Padding for further use"
             ],
             "type": {
               "array": [
                 "u64",
-                6
+                3
               ]
             }
           },
@@ -6607,6 +6204,20 @@
                 "name": "BaseFeeParameters"
               }
             }
+          },
+          {
+            "name": "compounding_fee_bps",
+            "docs": [
+              "compounding fee bps, only have value if CollectFeeMode::Compounding"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding for future use"
+            ],
+            "type": "u8"
           },
           {
             "name": "dynamic_fee",
@@ -6654,7 +6265,7 @@
             "type": "u8"
           },
           {
-            "name": "partner_fee_percent",
+            "name": "padding_0",
             "type": "u8"
           },
           {
@@ -6662,16 +6273,23 @@
             "type": "u8"
           },
           {
-            "name": "padding_0",
+            "name": "padding_1",
             "type": {
               "array": [
                 "u8",
-                5
+                3
               ]
             }
           },
           {
-            "name": "padding_1",
+            "name": "compounding_fee_bps",
+            "docs": [
+              "Compounding fee bps, only non-zero if collect_fee_mode is compounding"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "padding_2",
             "type": {
               "array": [
                 "u64",
@@ -6688,8 +6306,7 @@
         "Information regarding fee charges",
         "trading_fee = amount * trade_fee_numerator / denominator",
         "protocol_fee = trading_fee * protocol_fee_percentage / 100",
-        "referral_fee = protocol_fee * referral_percentage / 100",
-        "partner_fee = (protocol_fee - referral_fee) * partner_fee_percentage / denominator"
+        "referral_fee = protocol_fee * referral_percentage / 100"
       ],
       "serialization": "bytemuck",
       "repr": {
@@ -6722,9 +6339,9 @@
             "type": "u8"
           },
           {
-            "name": "partner_fee_percent",
+            "name": "padding_0",
             "docs": [
-              "partner fee"
+              "padding for future use"
             ],
             "type": "u8"
           },
@@ -6736,16 +6353,23 @@
             "type": "u8"
           },
           {
-            "name": "padding_0",
+            "name": "padding_1",
             "docs": [
               "padding"
             ],
             "type": {
               "array": [
                 "u8",
-                5
+                3
               ]
             }
+          },
+          {
+            "name": "compounding_fee_bps",
+            "docs": [
+              "compounding fee bps, only non-zero in CollectFeeMode::Compounding"
+            ],
+            "type": "u16"
           },
           {
             "name": "dynamic_fee",
@@ -6791,12 +6415,13 @@
             "type": "u64"
           },
           {
-            "name": "total_partner_a_fee",
-            "type": "u64"
-          },
-          {
-            "name": "total_partner_b_fee",
-            "type": "u64"
+            "name": "padding_0",
+            "type": {
+              "array": [
+                "u64",
+                2
+              ]
+            }
           },
           {
             "name": "total_position",
@@ -6916,14 +6541,32 @@
             }
           },
           {
+            "name": "inner_vesting",
+            "docs": [
+              "inner vesting info"
+            ],
+            "type": {
+              "defined": {
+                "name": "InnerVesting"
+              }
+            }
+          },
+          {
+            "name": "delegate_permission",
+            "docs": [
+              "delegate permission bitmask (paired with SPL token Approve)"
+            ],
+            "type": "u32"
+          },
+          {
             "name": "padding",
             "docs": [
               "padding for future usage"
             ],
             "type": {
               "array": [
-                "u128",
-                6
+                "u8",
+                12
               ]
             }
           }
@@ -7018,16 +6661,11 @@
             }
           },
           {
-            "name": "_padding_1",
+            "name": "dead_liquidity_reward_checkpoint",
             "docs": [
-              "Padding to ensure `reward_rate: u128` is 16-byte aligned"
+              "Cumulative dead-liquidity reward (Compounding Pool only)"
             ],
-            "type": {
-              "array": [
-                "u8",
-                8
-              ]
-            }
+            "type": "u64"
           },
           {
             "name": "mint",
@@ -7134,12 +6772,84 @@
       }
     },
     {
+      "name": "SplitAmountInfo2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "permanent_locked_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "unlocked_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "vested_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "fee_a",
+            "type": "u64"
+          },
+          {
+            "name": "fee_b",
+            "type": "u64"
+          },
+          {
+            "name": "reward_0",
+            "type": "u64"
+          },
+          {
+            "name": "reward_1",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
       "name": "SplitPositionInfo",
       "type": {
         "kind": "struct",
         "fields": [
           {
             "name": "liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "fee_a",
+            "type": "u64"
+          },
+          {
+            "name": "fee_b",
+            "type": "u64"
+          },
+          {
+            "name": "reward_0",
+            "type": "u64"
+          },
+          {
+            "name": "reward_1",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SplitPositionInfo2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "unlocked_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "permanent_locked_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "vested_liquidity",
             "type": "u128"
           },
           {
@@ -7209,6 +6919,13 @@
             "type": "u8"
           },
           {
+            "name": "inner_vesting_liquidity_percentage",
+            "docs": [
+              "Percentage of inner vesting liquidity"
+            ],
+            "type": "u8"
+          },
+          {
             "name": "padding",
             "docs": [
               "padding for future"
@@ -7216,7 +6933,7 @@
             "type": {
               "array": [
                 "u8",
-                16
+                15
               ]
             }
           }
@@ -7250,6 +6967,42 @@
           },
           {
             "name": "reward_1_numerator",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SplitPositionParameters3",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "unlocked_liquidity_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "permanent_locked_liquidity_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "fee_a_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "fee_b_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "reward_0_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "reward_1_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "inner_vesting_liquidity_numerator",
             "type": "u32"
           }
         ]
@@ -7366,7 +7119,7 @@
             "type": "u128"
           },
           {
-            "name": "trading_fee",
+            "name": "claiming_fee",
             "type": "u64"
           },
           {
@@ -7374,7 +7127,7 @@
             "type": "u64"
           },
           {
-            "name": "partner_fee",
+            "name": "compounding_fee",
             "type": "u64"
           },
           {
@@ -7449,6 +7202,17 @@
                 }
               }
             }
+          },
+          {
+            "name": "compounding_fee_bps",
+            "docs": [
+              "Compounding fee update mode:",
+              "- None: skip compounding fee update",
+              "- Some: update compounding_fee_bps; pool must use CollectFeeMode::Compounding"
+            ],
+            "type": {
+              "option": "u16"
+            }
           }
         ]
       }
@@ -7505,36 +7269,11 @@
             "type": "pubkey"
           },
           {
-            "name": "cliff_point",
-            "type": "u64"
-          },
-          {
-            "name": "period_frequency",
-            "type": "u64"
-          },
-          {
-            "name": "cliff_unlock_liquidity",
-            "type": "u128"
-          },
-          {
-            "name": "liquidity_per_period",
-            "type": "u128"
-          },
-          {
-            "name": "total_released_liquidity",
-            "type": "u128"
-          },
-          {
-            "name": "number_of_period",
-            "type": "u16"
-          },
-          {
-            "name": "padding",
+            "name": "inner_vesting",
             "type": {
-              "array": [
-                "u8",
-                14
-              ]
+              "defined": {
+                "name": "InnerVesting"
+              }
             }
           },
           {
@@ -7597,6 +7336,11 @@
       "value": "[203, 16, 199, 186, 184, 141, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0]"
     },
     {
+      "name": "CURRENT_POOL_VERSION",
+      "type": "u8",
+      "value": "1"
+    },
+    {
       "name": "CUSTOMIZABLE_POOL_PREFIX",
       "type": "bytes",
       "value": "[99, 112, 111, 111, 108]"
@@ -7614,8 +7358,18 @@
       "docs": [
         "Max basis point. 100% in pct"
       ],
-      "type": "u64",
+      "type": "u16",
       "value": "10000"
+    },
+    {
+      "name": "MAX_FEE_NUMERATOR_V0",
+      "type": "u64",
+      "value": "500000000"
+    },
+    {
+      "name": "MAX_FEE_NUMERATOR_V1",
+      "type": "u64",
+      "value": "990000000"
     },
     {
       "name": "MAX_SQRT_PRICE_LE_BYTES",
@@ -7626,6 +7380,11 @@
         ]
       },
       "value": "[155, 87, 105, 78, 169, 26, 92, 132, 177, 196, 254, 255, 0, 0, 0, 0]"
+    },
+    {
+      "name": "MIN_FEE_NUMERATOR",
+      "type": "u64",
+      "value": "100000"
     },
     {
       "name": "MIN_SQRT_PRICE_LE_BYTES",

--- a/idl/meteora_dlmm.json
+++ b/idl/meteora_dlmm.json
@@ -1,500 +1,1993 @@
 {
-  "version": "0.9.0",
-  "name": "lb_clmm",
-  "constants": [
-    {
-      "name": "BASIS_POINT_MAX",
-      "type": "i32",
-      "value": "10000"
-    },
-    {
-      "name": "MAX_BIN_PER_ARRAY",
-      "type": {
-        "defined": "usize"
-      },
-      "value": "70"
-    },
-    {
-      "name": "MAX_BIN_PER_POSITION",
-      "type": {
-        "defined": "usize"
-      },
-      "value": "70"
-    },
-    {
-      "name": "MAX_RESIZE_LENGTH",
-      "type": {
-        "defined": "usize"
-      },
-      "value": "70"
-    },
-    {
-      "name": "POSITION_MAX_LENGTH",
-      "type": {
-        "defined": "usize"
-      },
-      "value": "1400"
-    },
-    {
-      "name": "MIN_BIN_ID",
-      "type": "i32",
-      "value": "- 443636"
-    },
-    {
-      "name": "MAX_BIN_ID",
-      "type": "i32",
-      "value": "443636"
-    },
-    {
-      "name": "MAX_FEE_RATE",
-      "type": "u64",
-      "value": "100_000_000"
-    },
-    {
-      "name": "FEE_PRECISION",
-      "type": "u64",
-      "value": "1_000_000_000"
-    },
-    {
-      "name": "MAX_PROTOCOL_SHARE",
-      "type": "u16",
-      "value": "2_500"
-    },
-    {
-      "name": "HOST_FEE_BPS",
-      "type": "u16",
-      "value": "2_000"
-    },
-    {
-      "name": "NUM_REWARDS",
-      "type": {
-        "defined": "usize"
-      },
-      "value": "2"
-    },
-    {
-      "name": "MIN_REWARD_DURATION",
-      "type": "u64",
-      "value": "1"
-    },
-    {
-      "name": "MAX_REWARD_DURATION",
-      "type": "u64",
-      "value": "31536000"
-    },
-    {
-      "name": "EXTENSION_BINARRAY_BITMAP_SIZE",
-      "type": {
-        "defined": "usize"
-      },
-      "value": "12"
-    },
-    {
-      "name": "BIN_ARRAY_BITMAP_SIZE",
-      "type": "i32",
-      "value": "512"
-    },
-    {
-      "name": "MAX_REWARD_BIN_SPLIT",
-      "type": {
-        "defined": "usize"
-      },
-      "value": "15"
-    },
-    {
-      "name": "ILM_PROTOCOL_SHARE",
-      "type": "u16",
-      "value": "2000"
-    },
-    {
-      "name": "PROTOCOL_SHARE",
-      "type": "u16",
-      "value": "500"
-    },
-    {
-      "name": "MAX_BIN_STEP",
-      "type": "u16",
-      "value": "400"
-    },
-    {
-      "name": "MAX_BASE_FEE",
-      "type": "u128",
-      "value": "100_000_000"
-    },
-    {
-      "name": "MIN_BASE_FEE",
-      "type": "u128",
-      "value": "100_000"
-    },
-    {
-      "name": "MINIMUM_LIQUIDITY",
-      "type": "u128",
-      "value": "1_000_000"
-    },
-    {
-      "name": "BIN_ARRAY",
-      "type": "bytes",
-      "value": "[98, 105, 110, 95, 97, 114, 114, 97, 121]"
-    },
-    {
-      "name": "ORACLE",
-      "type": "bytes",
-      "value": "[111, 114, 97, 99, 108, 101]"
-    },
-    {
-      "name": "BIN_ARRAY_BITMAP_SEED",
-      "type": "bytes",
-      "value": "[98, 105, 116, 109, 97, 112]"
-    },
-    {
-      "name": "PRESET_PARAMETER",
-      "type": "bytes",
-      "value": "[112, 114, 101, 115, 101, 116, 95, 112, 97, 114, 97, 109, 101, 116, 101, 114]"
-    },
-    {
-      "name": "PRESET_PARAMETER2",
-      "type": "bytes",
-      "value": "[112, 114, 101, 115, 101, 116, 95, 112, 97, 114, 97, 109, 101, 116, 101, 114, 50]"
-    },
-    {
-      "name": "POSITION",
-      "type": "bytes",
-      "value": "[112, 111, 115, 105, 116, 105, 111, 110]"
-    },
-    {
-      "name": "CLAIM_PROTOCOL_FEE_OPERATOR",
-      "type": "bytes",
-      "value": "[99, 102, 95, 111, 112, 101, 114, 97, 116, 111, 114]"
-    }
-  ],
+  "address": "LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo",
+  "metadata": {
+    "name": "lb_clmm",
+    "version": "0.12.0",
+    "spec": "0.1.0",
+    "description": "Created with Anchor"
+  },
   "instructions": [
     {
-      "name": "initializeLbPair",
+      "name": "add_liquidity",
+      "discriminator": [181, 157, 89, 67, 143, 182, 52, 72],
       "accounts": [
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
+          "name": "position",
+          "writable": true
         },
         {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenMintX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "presetParameter",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "activeId",
-          "type": "i32"
-        },
-        {
-          "name": "binStep",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "initializePermissionLbPair",
-      "accounts": [
-        {
-          "name": "base",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenMintX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenBadgeX",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenBadgeY",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenProgramX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "ixData",
-          "type": {
-            "defined": "InitPermissionPairIx"
-          }
-        }
-      ]
-    },
-    {
-      "name": "initializeCustomizablePermissionlessLbPair",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenMintX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "params",
-          "type": {
-            "defined": "CustomizableParams"
-          }
-        }
-      ]
-    },
-    {
-      "name": "initializeBinArrayBitmapExtension",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Initialize an account to store if a bin array is initialized."
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "position",
+            "bin_array_bitmap_extension",
+            "bin_array_lower",
+            "bin_array_upper"
           ]
         },
         {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "user_token_x",
+          "writable": true
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_y_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity_parameter",
+          "type": {
+            "defined": {
+              "name": "LiquidityParameter"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "add_liquidity2",
+      "discriminator": [228, 162, 78, 28, 70, 219, 116, 115],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_bitmap_extension"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity_parameter",
+          "type": {
+            "defined": {
+              "name": "LiquidityParameter"
+            }
+          }
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "add_liquidity_by_strategy",
+      "discriminator": [7, 3, 150, 127, 148, 40, 61, 200],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "position",
+            "bin_array_bitmap_extension",
+            "bin_array_lower",
+            "bin_array_upper"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_y_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity_parameter",
+          "type": {
+            "defined": {
+              "name": "LiquidityParameterByStrategy"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "add_liquidity_by_strategy2",
+      "discriminator": [3, 221, 149, 218, 111, 141, 118, 213],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_bitmap_extension"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity_parameter",
+          "type": {
+            "defined": {
+              "name": "LiquidityParameterByStrategy"
+            }
+          }
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "add_liquidity_by_strategy_one_side",
+      "discriminator": [41, 5, 238, 175, 100, 225, 6, 205],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "position",
+            "bin_array_bitmap_extension",
+            "bin_array_lower",
+            "bin_array_upper"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token",
+          "writable": true
+        },
+        {
+          "name": "reserve",
+          "writable": true
+        },
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity_parameter",
+          "type": {
+            "defined": {
+              "name": "LiquidityParameterByStrategyOneSide"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "add_liquidity_by_weight",
+      "discriminator": [28, 140, 238, 99, 231, 162, 21, 149],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "position",
+            "bin_array_bitmap_extension",
+            "bin_array_lower",
+            "bin_array_upper"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_y_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity_parameter",
+          "type": {
+            "defined": {
+              "name": "LiquidityParameterByWeight"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "add_liquidity_by_weight2",
+      "discriminator": [209, 59, 63, 91, 111, 200, 153, 228],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_bitmap_extension"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity_parameter",
+          "type": {
+            "defined": {
+              "name": "LiquidityParameterByWeight"
+            }
+          }
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "add_liquidity_one_side",
+      "discriminator": [94, 155, 103, 151, 70, 95, 220, 165],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "position",
+            "bin_array_bitmap_extension",
+            "bin_array_lower",
+            "bin_array_upper"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token",
+          "writable": true
+        },
+        {
+          "name": "reserve",
+          "writable": true
+        },
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity_parameter",
+          "type": {
+            "defined": {
+              "name": "LiquidityOneSideParameter"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "add_liquidity_one_side_precise",
+      "discriminator": [161, 194, 103, 84, 171, 71, 250, 154],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "position",
+            "bin_array_bitmap_extension",
+            "bin_array_lower",
+            "bin_array_upper"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token",
+          "writable": true
+        },
+        {
+          "name": "reserve",
+          "writable": true
+        },
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "parameter",
+          "type": {
+            "defined": {
+              "name": "AddLiquiditySingleSidePreciseParameter"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "add_liquidity_one_side_precise2",
+      "discriminator": [33, 51, 163, 201, 117, 98, 125, 231],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_bitmap_extension"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token",
+          "writable": true
+        },
+        {
+          "name": "reserve",
+          "writable": true
+        },
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity_parameter",
+          "type": {
+            "defined": {
+              "name": "AddLiquiditySingleSidePreciseParameter2"
+            }
+          }
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "cancel_limit_order",
+      "discriminator": [132, 156, 132, 31, 67, 40, 232, 97],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array_bitmap_extension", "limit_order"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "limit_order",
+          "writable": true
+        },
+        {
+          "name": "owner_token_x",
+          "docs": [
+            "When dont set it tokenAccount to prevent unnecessary create token account (rent fee) when user only withdraw token y"
+          ],
+          "writable": true
+        },
+        {
+          "name": "owner_token_y",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        },
+        {
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "bins",
+          "type": {
+            "vec": "i32"
+          }
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "claim_fee",
+      "discriminator": [169, 32, 79, 137, 136, 232, 70, 137],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_lower", "bin_array_upper"]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
         }
       ],
       "args": []
     },
     {
-      "name": "initializeBinArray",
+      "name": "claim_fee2",
+      "discriminator": [112, 191, 101, 171, 28, 144, 127, 187],
       "accounts": [
         {
-          "name": "lbPair",
-          "isMut": false,
-          "isSigner": false
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position"]
         },
         {
-          "name": "binArray",
-          "isMut": true,
-          "isSigner": false
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_program_x"
+        },
+        {
+          "name": "token_program_y"
+        },
+        {
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "min_bin_id",
+          "type": "i32"
+        },
+        {
+          "name": "max_bin_id",
+          "type": "i32"
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "claim_reward",
+      "discriminator": [149, 95, 181, 242, 94, 90, 158, 162],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_lower", "bin_array_upper"]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "reward_vault",
+          "writable": true
+        },
+        {
+          "name": "reward_mint"
+        },
+        {
+          "name": "user_token_account",
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "claim_reward2",
+      "discriminator": [190, 3, 127, 119, 178, 87, 157, 183],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position"]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "reward_vault",
+          "writable": true
+        },
+        {
+          "name": "reward_mint"
+        },
+        {
+          "name": "user_token_account",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u64"
+        },
+        {
+          "name": "min_bin_id",
+          "type": "i32"
+        },
+        {
+          "name": "max_bin_id",
+          "type": "i32"
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "close_bin_array",
+      "discriminator": [68, 174, 88, 80, 181, 204, 19, 224],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "relations": ["bin_array"]
+        },
+        {
+          "name": "bin_array",
+          "writable": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_claim_fee_operator_account",
+      "discriminator": [184, 213, 88, 31, 179, 101, 130, 36],
+      "accounts": [
+        {
+          "name": "claim_fee_operator",
+          "writable": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_limit_order_if_empty",
+      "discriminator": [57, 124, 36, 155, 126, 249, 93, 171],
+      "accounts": [
+        {
+          "name": "limit_order",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_operator_account",
+      "discriminator": [171, 9, 213, 74, 120, 23, 3, 29],
+      "accounts": [
+        {
+          "name": "operator",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_position",
+      "discriminator": [123, 134, 81, 0, 49, 68, 98, 98],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_position2",
+      "discriminator": [174, 90, 35, 115, 186, 40, 147, 226],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_position_if_empty",
+      "discriminator": [59, 124, 212, 118, 91, 152, 110, 157],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_preset_parameter",
+      "discriminator": [4, 148, 145, 100, 134, 26, 181, 61],
+      "accounts": [
+        {
+          "name": "preset_parameter",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_preset_parameter2",
+      "discriminator": [39, 25, 95, 107, 116, 17, 115, 28],
+      "accounts": [
+        {
+          "name": "preset_parameter",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_token_badge",
+      "discriminator": [108, 146, 86, 110, 179, 254, 10, 104],
+      "accounts": [
+        {
+          "name": "token_badge",
+          "writable": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "create_operator_account",
+      "discriminator": [221, 64, 246, 149, 240, 153, 229, 163],
+      "accounts": [
+        {
+          "name": "operator",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [111, 112, 101, 114, 97, 116, 111, 114]
+              },
+              {
+                "kind": "account",
+                "path": "whitelisted_signer"
+              }
+            ]
+          }
+        },
+        {
+          "name": "whitelisted_signer"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "permission",
+          "type": "u128"
+        }
+      ]
+    },
+    {
+      "name": "decrease_position_length",
+      "discriminator": [194, 219, 136, 32, 25, 96, 105, 37],
+      "accounts": [
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "signer": true,
+          "relations": ["position"]
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "length_to_remove",
+          "type": "u16"
+        },
+        {
+          "name": "side",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "for_idl_type_generation_do_not_call",
+      "discriminator": [180, 105, 69, 80, 95, 50, 73, 108],
+      "accounts": [
+        {
+          "name": "dummy_zc_account"
+        }
+      ],
+      "args": [
+        {
+          "name": "_ix",
+          "type": {
+            "defined": {
+              "name": "DummyIx"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "fund_reward",
+      "discriminator": [188, 50, 249, 165, 93, 151, 38, 63],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array"]
+        },
+        {
+          "name": "reward_vault",
+          "writable": true
+        },
+        {
+          "name": "reward_mint"
+        },
+        {
+          "name": "funder_token_account",
+          "writable": true
         },
         {
           "name": "funder",
-          "isMut": true,
-          "isSigner": true
+          "signer": true
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "bin_array",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u64"
+        },
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "carry_forward",
+          "type": "bool"
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "go_to_a_bin",
+      "discriminator": [146, 72, 174, 224, 40, 253, 84, 174],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "bin_array_bitmap_extension",
+            "from_bin_array",
+            "to_bin_array"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "optional": true
+        },
+        {
+          "name": "from_bin_array",
+          "optional": true
+        },
+        {
+          "name": "to_bin_array",
+          "optional": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "bin_id",
+          "type": "i32"
+        }
+      ]
+    },
+    {
+      "name": "increase_oracle_length",
+      "discriminator": [190, 61, 125, 87, 103, 79, 158, 173],
+      "accounts": [
+        {
+          "name": "oracle",
+          "writable": true
+        },
+        {
+          "name": "funder",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "length_to_add",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "increase_position_length",
+      "discriminator": [80, 83, 117, 211, 66, 13, 33, 149],
+      "accounts": [
+        {
+          "name": "funder",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "lb_pair",
+          "relations": ["position"]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "signer": true,
+          "relations": ["position"]
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "length_to_add",
+          "type": "u16"
+        },
+        {
+          "name": "side",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "increase_position_length2",
+      "discriminator": [255, 210, 204, 71, 115, 137, 225, 113],
+      "accounts": [
+        {
+          "name": "funder",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "lb_pair",
+          "relations": ["position"]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "signer": true,
+          "relations": ["position"]
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "minimum_upper_bin_id",
+          "type": "i32"
+        }
+      ]
+    },
+    {
+      "name": "initialize_bin_array",
+      "discriminator": [35, 86, 19, 185, 78, 212, 75, 211],
+      "accounts": [
+        {
+          "name": "lb_pair"
+        },
+        {
+          "name": "bin_array",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [98, 105, 110, 95, 97, 114, 114, 97, 121]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "arg",
+                "path": "index"
+              }
+            ]
+          }
+        },
+        {
+          "name": "funder",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         }
       ],
       "args": [
@@ -505,578 +1998,762 @@
       ]
     },
     {
-      "name": "addLiquidity",
+      "name": "initialize_bin_array_bitmap_extension",
+      "discriminator": [47, 157, 226, 180, 12, 240, 33, 71],
       "accounts": [
         {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
+          "name": "lb_pair"
         },
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
+          "name": "bin_array_bitmap_extension",
+          "docs": [
+            "Initialize an account to store if a bin array is initialized."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [98, 105, 116, 109, 97, 112]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
+          }
         },
         {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
+          "name": "funder",
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         },
         {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "rent"
         }
       ],
-      "args": [
-        {
-          "name": "liquidityParameter",
-          "type": {
-            "defined": "LiquidityParameter"
-          }
-        }
-      ]
+      "args": []
     },
     {
-      "name": "addLiquidityByWeight",
+      "name": "initialize_customizable_permissionless_lb_pair",
+      "discriminator": [46, 39, 41, 135, 111, 183, 200, 64],
       "accounts": [
         {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
+          "name": "lb_pair",
+          "writable": true
         },
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityParameter",
-          "type": {
-            "defined": "LiquidityParameterByWeight"
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [98, 105, 116, 109, 97, 112]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
           }
-        }
-      ]
-    },
-    {
-      "name": "addLiquidityByStrategy",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
         },
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
+          "name": "token_mint_x"
         },
         {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
+          "name": "token_mint_y"
         },
         {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityParameter",
-          "type": {
-            "defined": "LiquidityParameterByStrategy"
+          "name": "reserve_x",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_x"
+              }
+            ]
           }
-        }
-      ]
-    },
-    {
-      "name": "addLiquidityByStrategyOneSide",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
         },
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userToken",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityParameter",
-          "type": {
-            "defined": "LiquidityParameterByStrategyOneSide"
+          "name": "reserve_y",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_y"
+              }
+            ]
           }
-        }
-      ]
-    },
-    {
-      "name": "addLiquidityOneSide",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
         },
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userToken",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityParameter",
-          "type": {
-            "defined": "LiquidityOneSideParameter"
+          "name": "oracle",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [111, 114, 97, 99, 108, 101]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
           }
-        }
-      ]
-    },
-    {
-      "name": "removeLiquidity",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
         },
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_x"
         },
         {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
+          "name": "funder",
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
         {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         },
         {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_y"
         },
         {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
         },
         {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "binLiquidityRemoval",
+          "name": "params",
           "type": {
-            "vec": {
-              "defined": "BinLiquidityReduction"
+            "defined": {
+              "name": "CustomizableParams"
             }
           }
         }
       ]
     },
     {
-      "name": "initializePosition",
+      "name": "initialize_customizable_permissionless_lb_pair2",
+      "discriminator": [243, 73, 129, 126, 51, 19, 241, 107],
       "accounts": [
         {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true
+          "name": "lb_pair",
+          "writable": true
         },
         {
-          "name": "position",
-          "isMut": true,
-          "isSigner": true
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [98, 105, 116, 109, 97, 112]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
+          }
         },
         {
-          "name": "lbPair",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_mint_x"
         },
         {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": true
+          "name": "token_mint_y"
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "reserve_x",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_x"
+              }
+            ]
+          }
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
+          "name": "reserve_y",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_y"
+              }
+            ]
+          }
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
+          "name": "oracle",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [111, 114, 97, 99, 108, 101]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
+          }
         },
         {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "user_token_x"
+        },
+        {
+          "name": "funder",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_badge_x",
+          "optional": true
+        },
+        {
+          "name": "token_badge_y",
+          "optional": true
+        },
+        {
+          "name": "token_program_x"
+        },
+        {
+          "name": "token_program_y"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "user_token_y"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "lowerBinId",
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "CustomizableParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "initialize_lb_pair",
+      "discriminator": [45, 154, 237, 210, 221, 15, 166, 92],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [98, 105, 116, 109, 97, 112]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_mint_x"
+        },
+        {
+          "name": "token_mint_y"
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_x"
+              }
+            ]
+          }
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_y"
+              }
+            ]
+          }
+        },
+        {
+          "name": "oracle",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [111, 114, 97, 99, 108, 101]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
+          }
+        },
+        {
+          "name": "preset_parameter"
+        },
+        {
+          "name": "funder",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "rent"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "active_id",
+          "type": "i32"
+        },
+        {
+          "name": "bin_step",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "initialize_lb_pair2",
+      "discriminator": [73, 59, 36, 120, 237, 83, 108, 198],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [98, 105, 116, 109, 97, 112]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_mint_x"
+        },
+        {
+          "name": "token_mint_y"
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_x"
+              }
+            ]
+          }
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_y"
+              }
+            ]
+          }
+        },
+        {
+          "name": "oracle",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [111, 114, 97, 99, 108, 101]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
+          }
+        },
+        {
+          "name": "preset_parameter"
+        },
+        {
+          "name": "funder",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_badge_x",
+          "optional": true
+        },
+        {
+          "name": "token_badge_y",
+          "optional": true
+        },
+        {
+          "name": "token_program_x"
+        },
+        {
+          "name": "token_program_y"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "InitializeLbPair2Params"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "initialize_permission_lb_pair",
+      "discriminator": [108, 102, 213, 85, 251, 3, 53, 21],
+      "accounts": [
+        {
+          "name": "base",
+          "signer": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [98, 105, 116, 109, 97, 112]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_mint_x"
+        },
+        {
+          "name": "token_mint_y"
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_x"
+              }
+            ]
+          }
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_y"
+              }
+            ]
+          }
+        },
+        {
+          "name": "oracle",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [111, 114, 97, 99, 108, 101]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              }
+            ]
+          }
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "token_badge_x",
+          "optional": true
+        },
+        {
+          "name": "token_badge_y",
+          "optional": true
+        },
+        {
+          "name": "token_program_x"
+        },
+        {
+          "name": "token_program_y"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "ix_data",
+          "type": {
+            "defined": {
+              "name": "InitPermissionPairIx"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "initialize_position",
+      "discriminator": [219, 192, 234, 71, 190, 191, 102, 80],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "position",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "lb_pair"
+        },
+        {
+          "name": "owner",
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "rent"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "lower_bin_id",
           "type": "i32"
         },
         {
@@ -1086,60 +2763,51 @@
       ]
     },
     {
-      "name": "initializePositionPda",
+      "name": "initialize_position2",
+      "discriminator": [143, 19, 242, 145, 213, 15, 104, 115],
       "accounts": [
         {
           "name": "payer",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "base",
-          "isMut": false,
-          "isSigner": true
+          "writable": true,
+          "signer": true
         },
         {
           "name": "position",
-          "isMut": true,
-          "isSigner": false
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "lbPair",
-          "isMut": false,
-          "isSigner": false
+          "name": "lb_pair"
         },
         {
           "name": "owner",
-          "isMut": false,
-          "isSigner": true,
-          "docs": [
-            "owner"
-          ]
+          "signer": true
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "lowerBinId",
+          "name": "lower_bin_id",
           "type": "i32"
         },
         {
@@ -1149,70 +2817,88 @@
       ]
     },
     {
-      "name": "initializePositionByOperator",
+      "name": "initialize_position_by_operator",
+      "discriminator": [251, 189, 190, 244, 117, 254, 35, 148],
       "accounts": [
         {
           "name": "payer",
-          "isMut": true,
-          "isSigner": true
+          "writable": true,
+          "signer": true
         },
         {
           "name": "base",
-          "isMut": false,
-          "isSigner": true
+          "signer": true
         },
         {
           "name": "position",
-          "isMut": true,
-          "isSigner": false
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [112, 111, 115, 105, 116, 105, 111, 110]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "base"
+              },
+              {
+                "kind": "arg",
+                "path": "lower_bin_id"
+              },
+              {
+                "kind": "arg",
+                "path": "width"
+              }
+            ]
+          }
         },
         {
-          "name": "lbPair",
-          "isMut": false,
-          "isSigner": false
+          "name": "lb_pair"
         },
         {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": false
+          "name": "owner"
         },
         {
           "name": "operator",
-          "isMut": false,
-          "isSigner": true,
-          "docs": [
-            "operator"
-          ]
+          "docs": ["operator"],
+          "signer": true
         },
         {
-          "name": "operatorTokenX",
-          "isMut": false,
-          "isSigner": false
+          "name": "operator_token_x"
         },
         {
-          "name": "ownerTokenX",
-          "isMut": false,
-          "isSigner": false
+          "name": "owner_token_x"
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
         },
         {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "lowerBinId",
+          "name": "lower_bin_id",
           "type": "i32"
         },
         {
@@ -1220,5733 +2906,2316 @@
           "type": "i32"
         },
         {
-          "name": "feeOwner",
-          "type": "publicKey"
+          "name": "fee_owner",
+          "type": "pubkey"
         },
         {
-          "name": "lockReleasePoint",
+          "name": "lock_release_point",
           "type": "u64"
         }
       ]
     },
     {
-      "name": "updatePositionOperator",
+      "name": "initialize_position_pda",
+      "discriminator": [46, 82, 125, 146, 85, 141, 228, 153],
       "accounts": [
         {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "base",
+          "signer": true
+        },
+        {
           "name": "position",
-          "isMut": true,
-          "isSigner": false
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [112, 111, 115, 105, 116, 105, 111, 110]
+              },
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "account",
+                "path": "base"
+              },
+              {
+                "kind": "arg",
+                "path": "lower_bin_id"
+              },
+              {
+                "kind": "arg",
+                "path": "width"
+              }
+            ]
+          }
+        },
+        {
+          "name": "lb_pair"
         },
         {
           "name": "owner",
-          "isMut": false,
-          "isSigner": true
+          "docs": ["owner"],
+          "signer": true
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         },
         {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "rent"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "operator",
-          "type": "publicKey"
+          "name": "lower_bin_id",
+          "type": "i32"
+        },
+        {
+          "name": "width",
+          "type": "i32"
+        }
+      ]
+    },
+    {
+      "name": "initialize_preset_parameter",
+      "discriminator": [66, 188, 71, 211, 98, 109, 14, 186],
+      "accounts": [
+        {
+          "name": "preset_parameter",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112, 114, 101, 115, 101, 116, 95, 112, 97, 114, 97, 109, 101,
+                  116, 101, 114, 50
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "ix.index"
+              }
+            ]
+          }
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "ix",
+          "type": {
+            "defined": {
+              "name": "InitPresetParametersIx"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "initialize_reward",
+      "discriminator": [95, 135, 192, 196, 242, 129, 230, 68],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "reward_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "lb_pair"
+              },
+              {
+                "kind": "arg",
+                "path": "reward_index"
+              }
+            ]
+          }
+        },
+        {
+          "name": "reward_mint"
+        },
+        {
+          "name": "token_badge",
+          "optional": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u64"
+        },
+        {
+          "name": "reward_duration",
+          "type": "u64"
+        },
+        {
+          "name": "funder",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "initialize_token_badge",
+      "discriminator": [253, 77, 205, 95, 27, 224, 89, 223],
+      "accounts": [
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "token_badge",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [116, 111, 107, 101, 110, 95, 98, 97, 100, 103, 101]
+              },
+              {
+                "kind": "account",
+                "path": "token_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "place_limit_order",
+      "discriminator": [108, 176, 33, 186, 146, 229, 1, 197],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array_bitmap_extension"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "reserve",
+          "writable": true
+        },
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "limit_order",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "owner"
+        },
+        {
+          "name": "user_token",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "PlaceLimitOrderParams"
+            }
+          }
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "rebalance_liquidity",
+      "discriminator": [92, 4, 176, 193, 119, 185, 83, 9],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_bitmap_extension"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "owner",
+          "signer": true,
+          "relations": ["position"]
+        },
+        {
+          "name": "rent_payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        },
+        {
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "RebalanceLiquidityParams"
+            }
+          }
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "remove_all_liquidity",
+      "discriminator": [10, 51, 61, 35, 112, 105, 24, 85],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "position",
+            "bin_array_bitmap_extension",
+            "bin_array_lower",
+            "bin_array_upper"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_y_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "remove_liquidity",
+      "discriminator": [80, 85, 209, 72, 24, 206, 177, 108],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "position",
+            "bin_array_bitmap_extension",
+            "bin_array_lower",
+            "bin_array_upper"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_y_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "bin_liquidity_removal",
+          "type": {
+            "vec": {
+              "defined": {
+                "name": "BinLiquidityReduction"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "remove_liquidity2",
+      "discriminator": [230, 215, 82, 127, 241, 101, 227, 146],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_bitmap_extension"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        },
+        {
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "bin_liquidity_removal",
+          "type": {
+            "vec": {
+              "defined": {
+                "name": "BinLiquidityReduction"
+              }
+            }
+          }
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "remove_liquidity_by_range",
+      "discriminator": [26, 82, 102, 152, 240, 74, 105, 26],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": [
+            "position",
+            "bin_array_bitmap_extension",
+            "bin_array_lower",
+            "bin_array_upper"
+          ]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "bin_array_lower",
+          "writable": true
+        },
+        {
+          "name": "bin_array_upper",
+          "writable": true
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_y_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "from_bin_id",
+          "type": "i32"
+        },
+        {
+          "name": "to_bin_id",
+          "type": "i32"
+        },
+        {
+          "name": "bps_to_remove",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "remove_liquidity_by_range2",
+      "discriminator": [204, 2, 195, 145, 53, 145, 145, 205],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_bitmap_extension"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user_token_x",
+          "writable": true
+        },
+        {
+          "name": "user_token_y",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        },
+        {
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "from_bin_id",
+          "type": "i32"
+        },
+        {
+          "name": "to_bin_id",
+          "type": "i32"
+        },
+        {
+          "name": "bps_to_remove",
+          "type": "u16"
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "set_activation_point",
+      "discriminator": [91, 249, 15, 165, 26, 129, 254, 125],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "activation_point",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "set_pair_status",
+      "discriminator": [67, 248, 231, 137, 154, 149, 217, 174],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "status",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "set_pair_status_permissionless",
+      "discriminator": [78, 59, 152, 211, 70, 183, 46, 208],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "status",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "set_permissionless_operation_bits",
+      "discriminator": [84, 58, 203, 139, 163, 81, 190, 186],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "signer": true,
+          "relations": ["position"]
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "bits",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "set_pre_activation_duration",
+      "discriminator": [165, 61, 201, 244, 130, 159, 22, 100],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "pre_activation_duration",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "set_pre_activation_swap_address",
+      "discriminator": [57, 139, 47, 123, 216, 80, 223, 10],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "pre_activation_swap_address",
+          "type": "pubkey"
         }
       ]
     },
     {
       "name": "swap",
+      "discriminator": [248, 198, 158, 145, 225, 117, 135, 200],
       "accounts": [
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array_bitmap_extension"]
         },
         {
-          "name": "binArrayBitmapExtension",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
         },
         {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "userTokenIn",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_in",
+          "writable": true
         },
         {
-          "name": "userTokenOut",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_out",
+          "writable": true
         },
         {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
         },
         {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
         },
         {
           "name": "oracle",
-          "isMut": true,
-          "isSigner": false
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "hostFeeIn",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
+          "name": "host_fee_in",
+          "writable": true,
+          "optional": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true
+          "signer": true
         },
         {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_x_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
         {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_y_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
         },
         {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "amountIn",
+          "name": "amount_in",
           "type": "u64"
         },
         {
-          "name": "minAmountOut",
+          "name": "min_amount_out",
           "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "swapExactOut",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenIn",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenOut",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "hostFeeIn",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "user",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "maxInAmount",
-          "type": "u64"
-        },
-        {
-          "name": "outAmount",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "swapWithPriceImpact",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenIn",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenOut",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "hostFeeIn",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "user",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "amountIn",
-          "type": "u64"
-        },
-        {
-          "name": "activeId",
-          "type": {
-            "option": "i32"
-          }
-        },
-        {
-          "name": "maxPriceImpactBps",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "withdrawProtocolFee",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "receiverTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "receiverTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "claimFeeOperator",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "operator",
-          "isMut": false,
-          "isSigner": true,
-          "docs": [
-            "operator"
-          ]
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "amountX",
-          "type": "u64"
-        },
-        {
-          "name": "amountY",
-          "type": "u64"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
-        }
-      ]
-    },
-    {
-      "name": "initializeReward",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadge",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u64"
-        },
-        {
-          "name": "rewardDuration",
-          "type": "u64"
-        },
-        {
-          "name": "funder",
-          "type": "publicKey"
-        }
-      ]
-    },
-    {
-      "name": "fundReward",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funderTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "binArray",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u64"
-        },
-        {
-          "name": "amount",
-          "type": "u64"
-        },
-        {
-          "name": "carryForward",
-          "type": "bool"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
-        }
-      ]
-    },
-    {
-      "name": "updateRewardFunder",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u64"
-        },
-        {
-          "name": "newFunder",
-          "type": "publicKey"
-        }
-      ]
-    },
-    {
-      "name": "updateRewardDuration",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "binArray",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u64"
-        },
-        {
-          "name": "newDuration",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "claimReward",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "claimFee",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "closePosition",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "rentReceiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "updateBaseFeeParameters",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "feeParameter",
-          "type": {
-            "defined": "BaseFeeParameter"
-          }
-        }
-      ]
-    },
-    {
-      "name": "updateDynamicFeeParameters",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "feeParameter",
-          "type": {
-            "defined": "DynamicFeeParameter"
-          }
-        }
-      ]
-    },
-    {
-      "name": "increaseOracleLength",
-      "accounts": [
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "lengthToAdd",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "initializePresetParameter",
-      "accounts": [
-        {
-          "name": "presetParameter",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "ix",
-          "type": {
-            "defined": "InitPresetParametersIx"
-          }
-        }
-      ]
-    },
-    {
-      "name": "closePresetParameter",
-      "accounts": [
-        {
-          "name": "presetParameter",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "rentReceiver",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "closePresetParameter2",
-      "accounts": [
-        {
-          "name": "presetParameter",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "rentReceiver",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "removeAllLiquidity",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setPairStatus",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "status",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "migratePosition",
-      "accounts": [
-        {
-          "name": "positionV2",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionV1",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "owner",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rentReceiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "migrateBinArray",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "updateFeesAndRewards",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "withdrawIneligibleReward",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funderTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "binArray",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u64"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
-        }
-      ]
-    },
-    {
-      "name": "setActivationPoint",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "activationPoint",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "removeLiquidityByRange",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "fromBinId",
-          "type": "i32"
-        },
-        {
-          "name": "toBinId",
-          "type": "i32"
-        },
-        {
-          "name": "bpsToRemove",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "addLiquidityOneSidePrecise",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userToken",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "parameter",
-          "type": {
-            "defined": "AddLiquiditySingleSidePreciseParameter"
-          }
-        }
-      ]
-    },
-    {
-      "name": "goToABin",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "fromBinArray",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "toBinArray",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "binId",
-          "type": "i32"
-        }
-      ]
-    },
-    {
-      "name": "setPreActivationDuration",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "creator",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "preActivationDuration",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "setPreActivationSwapAddress",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "creator",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "preActivationSwapAddress",
-          "type": "publicKey"
-        }
-      ]
-    },
-    {
-      "name": "setPairStatusPermissionless",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "creator",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "status",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "initializeTokenBadge",
-      "accounts": [
-        {
-          "name": "tokenMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadge",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "createClaimProtocolFeeOperator",
-      "accounts": [
-        {
-          "name": "claimFeeOperator",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "operator",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "closeClaimProtocolFeeOperator",
-      "accounts": [
-        {
-          "name": "claimFeeOperator",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rentReceiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "initializePresetParameter2",
-      "accounts": [
-        {
-          "name": "presetParameter",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "ix",
-          "type": {
-            "defined": "InitPresetParameters2Ix"
-          }
-        }
-      ]
-    },
-    {
-      "name": "initializeLbPair2",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenMintX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "presetParameter",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenBadgeX",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenBadgeY",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenProgramX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "params",
-          "type": {
-            "defined": "InitializeLbPair2Params"
-          }
-        }
-      ]
-    },
-    {
-      "name": "initializeCustomizablePermissionlessLbPair2",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenMintX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenBadgeX",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenBadgeY",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenProgramX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "params",
-          "type": {
-            "defined": "CustomizableParams"
-          }
-        }
-      ]
-    },
-    {
-      "name": "claimFee2",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramX",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramY",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "minBinId",
-          "type": "i32"
-        },
-        {
-          "name": "maxBinId",
-          "type": "i32"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
-        }
-      ]
-    },
-    {
-      "name": "claimReward2",
-      "accounts": [
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u64"
-        },
-        {
-          "name": "minBinId",
-          "type": "i32"
-        },
-        {
-          "name": "maxBinId",
-          "type": "i32"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
-        }
-      ]
-    },
-    {
-      "name": "addLiquidity2",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityParameter",
-          "type": {
-            "defined": "LiquidityParameter"
-          }
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
-        }
-      ]
-    },
-    {
-      "name": "addLiquidityByStrategy2",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityParameter",
-          "type": {
-            "defined": "LiquidityParameterByStrategy"
-          }
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
-        }
-      ]
-    },
-    {
-      "name": "addLiquidityOneSidePrecise2",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userToken",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityParameter",
-          "type": {
-            "defined": "AddLiquiditySingleSidePreciseParameter2"
-          }
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
-        }
-      ]
-    },
-    {
-      "name": "removeLiquidity2",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "binLiquidityRemoval",
-          "type": {
-            "vec": {
-              "defined": "BinLiquidityReduction"
-            }
-          }
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
-        }
-      ]
-    },
-    {
-      "name": "removeLiquidityByRange2",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "binArrayBitmapExtension",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "userTokenX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userTokenY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "fromBinId",
-          "type": "i32"
-        },
-        {
-          "name": "toBinId",
-          "type": "i32"
-        },
-        {
-          "name": "bpsToRemove",
-          "type": "u16"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
         }
       ]
     },
     {
       "name": "swap2",
+      "discriminator": [65, 75, 63, 76, 235, 91, 91, 136],
       "accounts": [
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array_bitmap_extension"]
         },
         {
-          "name": "binArrayBitmapExtension",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
         },
         {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "userTokenIn",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_in",
+          "writable": true
         },
         {
-          "name": "userTokenOut",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_out",
+          "writable": true
         },
         {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
         },
         {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
         },
         {
           "name": "oracle",
-          "isMut": true,
-          "isSigner": false
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "hostFeeIn",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
+          "name": "host_fee_in",
+          "writable": true,
+          "optional": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true
+          "signer": true
         },
         {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_x_program"
         },
         {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_y_program"
         },
         {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
         },
         {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "amountIn",
+          "name": "amount_in",
           "type": "u64"
         },
         {
-          "name": "minAmountOut",
+          "name": "min_amount_out",
           "type": "u64"
         },
         {
-          "name": "remainingAccountsInfo",
+          "name": "remaining_accounts_info",
           "type": {
-            "defined": "RemainingAccountsInfo"
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
           }
         }
       ]
     },
     {
-      "name": "swapExactOut2",
+      "name": "swap_exact_out",
+      "discriminator": [250, 73, 101, 33, 38, 207, 75, 184],
       "accounts": [
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array_bitmap_extension"]
         },
         {
-          "name": "binArrayBitmapExtension",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
         },
         {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "userTokenIn",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_in",
+          "writable": true
         },
         {
-          "name": "userTokenOut",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_out",
+          "writable": true
         },
         {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
         },
         {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
         },
         {
           "name": "oracle",
-          "isMut": true,
-          "isSigner": false
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "hostFeeIn",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
+          "name": "host_fee_in",
+          "writable": true,
+          "optional": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true
+          "signer": true
         },
         {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_x_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
         {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_y_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
         {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "maxInAmount",
+          "name": "max_in_amount",
           "type": "u64"
         },
         {
-          "name": "outAmount",
+          "name": "out_amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "swap_exact_out2",
+      "discriminator": [43, 215, 247, 132, 137, 60, 243, 81],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array_bitmap_extension"]
+        },
+        {
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "user_token_in",
+          "writable": true
+        },
+        {
+          "name": "user_token_out",
+          "writable": true
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "oracle",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "host_fee_in",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user",
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        },
+        {
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_in_amount",
           "type": "u64"
         },
         {
-          "name": "remainingAccountsInfo",
+          "name": "out_amount",
+          "type": "u64"
+        },
+        {
+          "name": "remaining_accounts_info",
           "type": {
-            "defined": "RemainingAccountsInfo"
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
           }
         }
       ]
     },
     {
-      "name": "swapWithPriceImpact2",
+      "name": "swap_with_price_impact",
+      "discriminator": [56, 173, 230, 208, 173, 228, 156, 205],
       "accounts": [
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array_bitmap_extension"]
         },
         {
-          "name": "binArrayBitmapExtension",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
         },
         {
-          "name": "reserveX",
-          "isMut": true,
-          "isSigner": false
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "reserveY",
-          "isMut": true,
-          "isSigner": false
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "userTokenIn",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_in",
+          "writable": true
         },
         {
-          "name": "userTokenOut",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_out",
+          "writable": true
         },
         {
-          "name": "tokenXMint",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
         },
         {
-          "name": "tokenYMint",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
         },
         {
           "name": "oracle",
-          "isMut": true,
-          "isSigner": false
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "hostFeeIn",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
+          "name": "host_fee_in",
+          "writable": true,
+          "optional": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true
+          "signer": true
         },
         {
-          "name": "tokenXProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_x_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
         {
-          "name": "tokenYProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_y_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
         {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "amountIn",
+          "name": "amount_in",
           "type": "u64"
         },
         {
-          "name": "activeId",
+          "name": "active_id",
           "type": {
             "option": "i32"
           }
         },
         {
-          "name": "maxPriceImpactBps",
+          "name": "max_price_impact_bps",
           "type": "u16"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "defined": "RemainingAccountsInfo"
-          }
         }
       ]
     },
     {
-      "name": "closePosition2",
+      "name": "swap_with_price_impact2",
+      "discriminator": [74, 98, 192, 214, 177, 51, 75, 51],
       "accounts": [
         {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array_bitmap_extension"]
         },
         {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
+          "name": "bin_array_bitmap_extension",
+          "writable": true,
+          "optional": true
         },
         {
-          "name": "rentReceiver",
-          "isMut": true,
-          "isSigner": false
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
         },
         {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "updateFeesAndReward2",
-      "accounts": [
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_in",
+          "writable": true
         },
         {
-          "name": "lbPair",
-          "isMut": true,
-          "isSigner": false
+          "name": "user_token_out",
+          "writable": true
         },
         {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": true
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "oracle",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "host_fee_in",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "user",
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        },
+        {
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
         }
       ],
       "args": [
         {
-          "name": "minBinId",
+          "name": "amount_in",
+          "type": "u64"
+        },
+        {
+          "name": "active_id",
+          "type": {
+            "option": "i32"
+          }
+        },
+        {
+          "name": "max_price_impact_bps",
+          "type": "u16"
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "update_base_fee_parameters",
+      "discriminator": [75, 168, 223, 161, 16, 195, 3, 47],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "fee_parameter",
+          "type": {
+            "defined": {
+              "name": "BaseFeeParameter"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "update_dynamic_fee_parameters",
+      "discriminator": [92, 161, 46, 246, 255, 189, 22, 22],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "fee_parameter",
+          "type": {
+            "defined": {
+              "name": "DynamicFeeParameter"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "update_fees_and_reward2",
+      "discriminator": [32, 142, 184, 154, 103, 65, 184, 88],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position"]
+        },
+        {
+          "name": "owner",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "min_bin_id",
           "type": "i32"
         },
         {
-          "name": "maxBinId",
+          "name": "max_bin_id",
           "type": "i32"
         }
       ]
     },
     {
-      "name": "closePositionIfEmpty",
+      "name": "update_fees_and_rewards",
+      "discriminator": [154, 230, 250, 13, 236, 209, 75, 223],
       "accounts": [
         {
           "name": "position",
-          "isMut": true,
-          "isSigner": false
+          "writable": true
         },
         {
-          "name": "sender",
-          "isMut": false,
-          "isSigner": true
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["position", "bin_array_lower", "bin_array_upper"]
         },
         {
-          "name": "rentReceiver",
-          "isMut": true,
-          "isSigner": false
+          "name": "bin_array_lower",
+          "writable": true
         },
         {
-          "name": "eventAuthority",
-          "isMut": false,
-          "isSigner": false
+          "name": "bin_array_upper",
+          "writable": true
         },
         {
-          "name": "program",
-          "isMut": false,
-          "isSigner": false
+          "name": "owner",
+          "signer": true
         }
       ],
       "args": []
+    },
+    {
+      "name": "update_position_operator",
+      "discriminator": [202, 184, 103, 143, 180, 191, 116, 217],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "signer": true,
+          "relations": ["position"]
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "operator",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "update_reward_duration",
+      "discriminator": [138, 174, 196, 169, 213, 235, 254, 107],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array"]
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "bin_array",
+          "writable": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u64"
+        },
+        {
+          "name": "new_duration",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "update_reward_funder",
+      "discriminator": [211, 28, 48, 32, 215, 160, 35, 23],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u64"
+        },
+        {
+          "name": "new_funder",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "withdraw_ineligible_reward",
+      "discriminator": [148, 206, 42, 195, 247, 49, 103, 8],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true,
+          "relations": ["bin_array"]
+        },
+        {
+          "name": "reward_vault",
+          "writable": true
+        },
+        {
+          "name": "reward_mint"
+        },
+        {
+          "name": "funder_token_account",
+          "writable": true
+        },
+        {
+          "name": "funder",
+          "signer": true
+        },
+        {
+          "name": "bin_array",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "memo_program",
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "event_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u64"
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "withdraw_protocol_fee",
+      "discriminator": [158, 201, 158, 189, 33, 93, 162, 103],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "reserve_x",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "reserve_y",
+          "writable": true,
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_x_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "token_y_mint",
+          "relations": ["lb_pair"]
+        },
+        {
+          "name": "receiver_token_x",
+          "writable": true
+        },
+        {
+          "name": "receiver_token_y",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "docs": ["operator"],
+          "signer": true
+        },
+        {
+          "name": "token_x_program"
+        },
+        {
+          "name": "token_y_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount_x",
+          "type": "u64"
+        },
+        {
+          "name": "max_amount_y",
+          "type": "u64"
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "zap_protocol_fee",
+      "discriminator": [213, 155, 187, 34, 56, 182, 91, 240],
+      "accounts": [
+        {
+          "name": "lb_pair",
+          "writable": true
+        },
+        {
+          "name": "reserve",
+          "writable": true
+        },
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "receiver_token",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "docs": ["operator"],
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "sysvar_instructions",
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount",
+          "type": "u64"
+        },
+        {
+          "name": "remaining_accounts_info",
+          "type": {
+            "defined": {
+              "name": "RemainingAccountsInfo"
+            }
+          }
+        }
+      ]
     }
   ],
   "accounts": [
     {
-      "name": "BinArrayBitmapExtension",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "lbPair",
-            "type": "publicKey"
-          },
-          {
-            "name": "positiveBinArrayBitmap",
-            "docs": [
-              "Packed initialized bin array state for start_bin_index is positive"
-            ],
-            "type": {
-              "array": [
-                {
-                  "array": [
-                    "u64",
-                    8
-                  ]
-                },
-                12
-              ]
-            }
-          },
-          {
-            "name": "negativeBinArrayBitmap",
-            "docs": [
-              "Packed initialized bin array state for start_bin_index is negative"
-            ],
-            "type": {
-              "array": [
-                {
-                  "array": [
-                    "u64",
-                    8
-                  ]
-                },
-                12
-              ]
-            }
-          }
-        ]
-      }
+      "name": "BinArray",
+      "discriminator": [92, 142, 92, 220, 5, 148, 70, 181]
     },
     {
-      "name": "BinArray",
-      "docs": [
-        "An account to contain a range of bin. For example: Bin 100 <-> 200.",
-        "For example:",
-        "BinArray index: 0 contains bin 0 <-> 599",
-        "index: 2 contains bin 600 <-> 1199, ..."
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "index",
-            "type": "i64"
-          },
-          {
-            "name": "version",
-            "docs": [
-              "Version of binArray"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "padding",
-            "type": {
-              "array": [
-                "u8",
-                7
-              ]
-            }
-          },
-          {
-            "name": "lbPair",
-            "type": "publicKey"
-          },
-          {
-            "name": "bins",
-            "type": {
-              "array": [
-                {
-                  "defined": "Bin"
-                },
-                70
-              ]
-            }
-          }
-        ]
-      }
+      "name": "BinArrayBitmapExtension",
+      "discriminator": [80, 111, 124, 113, 55, 237, 18, 5]
     },
     {
       "name": "ClaimFeeOperator",
-      "docs": [
-        "Parameter that set by the protocol"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "operator",
-            "docs": [
-              "operator"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "padding",
-            "docs": [
-              "Reserve"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                128
-              ]
-            }
-          }
-        ]
-      }
+      "discriminator": [166, 48, 134, 86, 34, 200, 188, 150]
+    },
+    {
+      "name": "DummyZcAccount",
+      "discriminator": [94, 107, 238, 80, 208, 48, 180, 8]
     },
     {
       "name": "LbPair",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "parameters",
-            "type": {
-              "defined": "StaticParameters"
-            }
-          },
-          {
-            "name": "vParameters",
-            "type": {
-              "defined": "VariableParameters"
-            }
-          },
-          {
-            "name": "bumpSeed",
-            "type": {
-              "array": [
-                "u8",
-                1
-              ]
-            }
-          },
-          {
-            "name": "binStepSeed",
-            "docs": [
-              "Bin step signer seed"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                2
-              ]
-            }
-          },
-          {
-            "name": "pairType",
-            "docs": [
-              "Type of the pair"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "activeId",
-            "docs": [
-              "Active bin id"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "binStep",
-            "docs": [
-              "Bin step. Represent the price increment / decrement."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "status",
-            "docs": [
-              "Status of the pair. Check PairStatus enum."
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "requireBaseFactorSeed",
-            "docs": [
-              "Require base factor seed"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "baseFactorSeed",
-            "docs": [
-              "Base factor seed"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                2
-              ]
-            }
-          },
-          {
-            "name": "activationType",
-            "docs": [
-              "Activation type"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "creatorPoolOnOffControl",
-            "docs": [
-              "Allow pool creator to enable/disable pool with restricted validation. Only applicable for customizable permissionless pair type."
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "tokenXMint",
-            "docs": [
-              "Token X mint"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenYMint",
-            "docs": [
-              "Token Y mint"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "reserveX",
-            "docs": [
-              "LB token X vault"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "reserveY",
-            "docs": [
-              "LB token Y vault"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "protocolFee",
-            "docs": [
-              "Uncollected protocol fee"
-            ],
-            "type": {
-              "defined": "ProtocolFee"
-            }
-          },
-          {
-            "name": "padding1",
-            "docs": [
-              "_padding_1, previous Fee owner, BE CAREFUL FOR TOMBSTONE WHEN REUSE !!"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                32
-              ]
-            }
-          },
-          {
-            "name": "rewardInfos",
-            "docs": [
-              "Farming reward information"
-            ],
-            "type": {
-              "array": [
-                {
-                  "defined": "RewardInfo"
-                },
-                2
-              ]
-            }
-          },
-          {
-            "name": "oracle",
-            "docs": [
-              "Oracle pubkey"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "binArrayBitmap",
-            "docs": [
-              "Packed initialized bin array state"
-            ],
-            "type": {
-              "array": [
-                "u64",
-                16
-              ]
-            }
-          },
-          {
-            "name": "lastUpdatedAt",
-            "docs": [
-              "Last time the pool fee parameter was updated"
-            ],
-            "type": "i64"
-          },
-          {
-            "name": "padding2",
-            "docs": [
-              "_padding_2, previous whitelisted_wallet, BE CAREFUL FOR TOMBSTONE WHEN REUSE !!"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                32
-              ]
-            }
-          },
-          {
-            "name": "preActivationSwapAddress",
-            "docs": [
-              "Address allowed to swap when the current point is greater than or equal to the pre-activation point. The pre-activation point is calculated as `activation_point - pre_activation_duration`."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "baseKey",
-            "docs": [
-              "Base keypair. Only required for permission pair"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "activationPoint",
-            "docs": [
-              "Time point to enable the pair. Only applicable for permission pair."
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "preActivationDuration",
-            "docs": [
-              "Duration before activation activation_point. Used to calculate pre-activation time point for pre_activation_swap_address"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "padding3",
-            "docs": [
-              "_padding 3 is reclaimed free space from swap_cap_deactivate_point and swap_cap_amount before, BE CAREFUL FOR TOMBSTONE WHEN REUSE !!"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                8
-              ]
-            }
-          },
-          {
-            "name": "padding4",
-            "docs": [
-              "_padding_4, previous lock_duration, BE CAREFUL FOR TOMBSTONE WHEN REUSE !!"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "creator",
-            "docs": [
-              "Pool creator"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenMintXProgramFlag",
-            "docs": [
-              "token_mint_x_program_flag"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "tokenMintYProgramFlag",
-            "docs": [
-              "token_mint_y_program_flag"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "reserved",
-            "docs": [
-              "Reserved space for future use"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                22
-              ]
-            }
-          }
-        ]
-      }
+      "discriminator": [33, 11, 49, 98, 181, 101, 177, 13]
+    },
+    {
+      "name": "LimitOrder",
+      "discriminator": [137, 183, 212, 91, 115, 29, 141, 227]
+    },
+    {
+      "name": "Operator",
+      "discriminator": [219, 31, 188, 145, 69, 139, 204, 117]
     },
     {
       "name": "Oracle",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "idx",
-            "docs": [
-              "Index of latest observation"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "activeSize",
-            "docs": [
-              "Size of active sample. Active sample is initialized observation."
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "length",
-            "docs": [
-              "Number of observations"
-            ],
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Position",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "lbPair",
-            "docs": [
-              "The LB pair of this position"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "owner",
-            "docs": [
-              "Owner of the position. Client rely on this to to fetch their positions."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "liquidityShares",
-            "docs": [
-              "Liquidity shares of this position in bins (lower_bin_id <-> upper_bin_id). This is the same as LP concept."
-            ],
-            "type": {
-              "array": [
-                "u64",
-                70
-              ]
-            }
-          },
-          {
-            "name": "rewardInfos",
-            "docs": [
-              "Farming reward information"
-            ],
-            "type": {
-              "array": [
-                {
-                  "defined": "UserRewardInfo"
-                },
-                70
-              ]
-            }
-          },
-          {
-            "name": "feeInfos",
-            "docs": [
-              "Swap fee to claim information"
-            ],
-            "type": {
-              "array": [
-                {
-                  "defined": "FeeInfo"
-                },
-                70
-              ]
-            }
-          },
-          {
-            "name": "lowerBinId",
-            "docs": [
-              "Lower bin ID"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "upperBinId",
-            "docs": [
-              "Upper bin ID"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "lastUpdatedAt",
-            "docs": [
-              "Last updated timestamp"
-            ],
-            "type": "i64"
-          },
-          {
-            "name": "totalClaimedFeeXAmount",
-            "docs": [
-              "Total claimed token fee X"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "totalClaimedFeeYAmount",
-            "docs": [
-              "Total claimed token fee Y"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "totalClaimedRewards",
-            "docs": [
-              "Total claimed rewards"
-            ],
-            "type": {
-              "array": [
-                "u64",
-                2
-              ]
-            }
-          },
-          {
-            "name": "reserved",
-            "docs": [
-              "Reserved space for future use"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                160
-              ]
-            }
-          }
-        ]
-      }
+      "discriminator": [139, 194, 131, 179, 140, 179, 229, 244]
     },
     {
       "name": "PositionV2",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "lbPair",
-            "docs": [
-              "The LB pair of this position"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "owner",
-            "docs": [
-              "Owner of the position. Client rely on this to to fetch their positions."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "liquidityShares",
-            "docs": [
-              "Liquidity shares of this position in bins (lower_bin_id <-> upper_bin_id). This is the same as LP concept."
-            ],
-            "type": {
-              "array": [
-                "u128",
-                70
-              ]
-            }
-          },
-          {
-            "name": "rewardInfos",
-            "docs": [
-              "Farming reward information"
-            ],
-            "type": {
-              "array": [
-                {
-                  "defined": "UserRewardInfo"
-                },
-                70
-              ]
-            }
-          },
-          {
-            "name": "feeInfos",
-            "docs": [
-              "Swap fee to claim information"
-            ],
-            "type": {
-              "array": [
-                {
-                  "defined": "FeeInfo"
-                },
-                70
-              ]
-            }
-          },
-          {
-            "name": "lowerBinId",
-            "docs": [
-              "Lower bin ID"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "upperBinId",
-            "docs": [
-              "Upper bin ID"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "lastUpdatedAt",
-            "docs": [
-              "Last updated timestamp"
-            ],
-            "type": "i64"
-          },
-          {
-            "name": "totalClaimedFeeXAmount",
-            "docs": [
-              "Total claimed token fee X"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "totalClaimedFeeYAmount",
-            "docs": [
-              "Total claimed token fee Y"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "totalClaimedRewards",
-            "docs": [
-              "Total claimed rewards"
-            ],
-            "type": {
-              "array": [
-                "u64",
-                2
-              ]
-            }
-          },
-          {
-            "name": "operator",
-            "docs": [
-              "Operator of position"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "lockReleasePoint",
-            "docs": [
-              "Time point which the locked liquidity can be withdraw"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "padding0",
-            "docs": [
-              "_padding_0, previous subjected_to_bootstrap_liquidity_locking, BE CAREFUL FOR TOMBSTONE WHEN REUSE !!"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "feeOwner",
-            "docs": [
-              "Address is able to claim fee in this position, only valid for bootstrap_liquidity_position"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "reserved",
-            "docs": [
-              "Reserved space for future use"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                87
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "PresetParameter2",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "binStep",
-            "docs": [
-              "Bin step. Represent the price increment / decrement."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFactor",
-            "docs": [
-              "Used for base fee calculation. base_fee_rate = base_factor * bin_step * 10 * 10^base_fee_power_factor"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "filterPeriod",
-            "docs": [
-              "Filter period determine high frequency trading time window."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "decayPeriod",
-            "docs": [
-              "Decay period determine when the volatile fee start decay / decrease."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "variableFeeControl",
-            "docs": [
-              "Used to scale the variable fee component depending on the dynamic of the market"
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "maxVolatilityAccumulator",
-            "docs": [
-              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "reductionFactor",
-            "docs": [
-              "Reduction factor controls the volatile fee rate decrement rate."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "protocolShare",
-            "docs": [
-              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "index",
-            "docs": [
-              "index"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFeePowerFactor",
-            "docs": [
-              "Base fee power factor"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "padding0",
-            "docs": [
-              "Padding 0 for future use"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "padding1",
-            "docs": [
-              "Padding 1 for future use"
-            ],
-            "type": {
-              "array": [
-                "u64",
-                20
-              ]
-            }
-          }
-        ]
-      }
+      "discriminator": [117, 176, 212, 199, 245, 180, 133, 182]
     },
     {
       "name": "PresetParameter",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "binStep",
-            "docs": [
-              "Bin step. Represent the price increment / decrement."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFactor",
-            "docs": [
-              "Used for base fee calculation. base_fee_rate = base_factor * bin_step * 10 * 10^base_fee_power_factor"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "filterPeriod",
-            "docs": [
-              "Filter period determine high frequency trading time window."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "decayPeriod",
-            "docs": [
-              "Decay period determine when the volatile fee start decay / decrease."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "reductionFactor",
-            "docs": [
-              "Reduction factor controls the volatile fee rate decrement rate."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "variableFeeControl",
-            "docs": [
-              "Used to scale the variable fee component depending on the dynamic of the market"
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "maxVolatilityAccumulator",
-            "docs": [
-              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "minBinId",
-            "docs": [
-              "Min bin id supported by the pool based on the configured bin step."
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "maxBinId",
-            "docs": [
-              "Max bin id supported by the pool based on the configured bin step."
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "protocolShare",
-            "docs": [
-              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
-            ],
-            "type": "u16"
-          }
-        ]
-      }
+      "discriminator": [242, 62, 244, 34, 181, 112, 58, 170]
+    },
+    {
+      "name": "PresetParameter2",
+      "discriminator": [171, 236, 148, 115, 162, 113, 222, 174]
     },
     {
       "name": "TokenBadge",
-      "docs": [
-        "Parameter that set by the protocol"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "tokenMint",
-            "docs": [
-              "token mint"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "padding",
-            "docs": [
-              "Reserve"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                128
-              ]
-            }
-          }
-        ]
-      }
-    }
-  ],
-  "types": [
-    {
-      "name": "InitPresetParameters2Ix",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "index",
-            "type": "u16"
-          },
-          {
-            "name": "binStep",
-            "docs": [
-              "Bin step. Represent the price increment / decrement."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFactor",
-            "docs": [
-              "Used for base fee calculation. base_fee_rate = base_factor * bin_step * 10 * 10^base_fee_power_factor"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "filterPeriod",
-            "docs": [
-              "Filter period determine high frequency trading time window."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "decayPeriod",
-            "docs": [
-              "Decay period determine when the volatile fee start decay / decrease."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "reductionFactor",
-            "docs": [
-              "Reduction factor controls the volatile fee rate decrement rate."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "variableFeeControl",
-            "docs": [
-              "Used to scale the variable fee component depending on the dynamic of the market"
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "maxVolatilityAccumulator",
-            "docs": [
-              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "protocolShare",
-            "docs": [
-              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFeePowerFactor",
-            "docs": [
-              "Base fee power factor"
-            ],
-            "type": "u8"
-          }
-        ]
-      }
-    },
-    {
-      "name": "InitPresetParametersIx",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "binStep",
-            "docs": [
-              "Bin step. Represent the price increment / decrement."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFactor",
-            "docs": [
-              "Used for base fee calculation. base_fee_rate = base_factor * bin_step * 10 * 10^base_fee_power_factor"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "filterPeriod",
-            "docs": [
-              "Filter period determine high frequency trading time window."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "decayPeriod",
-            "docs": [
-              "Decay period determine when the volatile fee start decay / decrease."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "reductionFactor",
-            "docs": [
-              "Reduction factor controls the volatile fee rate decrement rate."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "variableFeeControl",
-            "docs": [
-              "Used to scale the variable fee component depending on the dynamic of the market"
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "maxVolatilityAccumulator",
-            "docs": [
-              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "protocolShare",
-            "docs": [
-              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
-            ],
-            "type": "u16"
-          }
-        ]
-      }
-    },
-    {
-      "name": "BaseFeeParameter",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "protocolShare",
-            "docs": [
-              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFactor",
-            "docs": [
-              "Base factor for base fee rate"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFeePowerFactor",
-            "docs": [
-              "Base fee power factor"
-            ],
-            "type": "u8"
-          }
-        ]
-      }
-    },
-    {
-      "name": "DynamicFeeParameter",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "filterPeriod",
-            "docs": [
-              "Filter period determine high frequency trading time window."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "decayPeriod",
-            "docs": [
-              "Decay period determine when the volatile fee start decay / decrease."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "reductionFactor",
-            "docs": [
-              "Reduction factor controls the volatile fee rate decrement rate."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "variableFeeControl",
-            "docs": [
-              "Used to scale the variable fee component depending on the dynamic of the market"
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "maxVolatilityAccumulator",
-            "docs": [
-              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
-            ],
-            "type": "u32"
-          }
-        ]
-      }
-    },
-    {
-      "name": "LiquidityParameterByStrategyOneSide",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "amount",
-            "docs": [
-              "Amount of X token or Y token to deposit"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "activeId",
-            "docs": [
-              "Active bin that integrator observe off-chain"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "maxActiveBinSlippage",
-            "docs": [
-              "max active bin slippage allowed"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "strategyParameters",
-            "docs": [
-              "strategy parameters"
-            ],
-            "type": {
-              "defined": "StrategyParameters"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "LiquidityParameterByStrategy",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "amountX",
-            "docs": [
-              "Amount of X token to deposit"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "amountY",
-            "docs": [
-              "Amount of Y token to deposit"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "activeId",
-            "docs": [
-              "Active bin that integrator observe off-chain"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "maxActiveBinSlippage",
-            "docs": [
-              "max active bin slippage allowed"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "strategyParameters",
-            "docs": [
-              "strategy parameters"
-            ],
-            "type": {
-              "defined": "StrategyParameters"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "StrategyParameters",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "minBinId",
-            "docs": [
-              "min bin id"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "maxBinId",
-            "docs": [
-              "max bin id"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "strategyType",
-            "docs": [
-              "strategy type"
-            ],
-            "type": {
-              "defined": "StrategyType"
-            }
-          },
-          {
-            "name": "parameteres",
-            "docs": [
-              "parameters"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                64
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "LiquidityOneSideParameter",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "amount",
-            "docs": [
-              "Amount of X token or Y token to deposit"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "activeId",
-            "docs": [
-              "Active bin that integrator observe off-chain"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "maxActiveBinSlippage",
-            "docs": [
-              "max active bin slippage allowed"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "binLiquidityDist",
-            "docs": [
-              "Liquidity distribution to each bins"
-            ],
-            "type": {
-              "vec": {
-                "defined": "BinLiquidityDistributionByWeight"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "BinLiquidityDistributionByWeight",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "binId",
-            "docs": [
-              "Define the bin ID wish to deposit to."
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "weight",
-            "docs": [
-              "weight of liquidity distributed for this bin id"
-            ],
-            "type": "u16"
-          }
-        ]
-      }
-    },
-    {
-      "name": "LiquidityParameterByWeight",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "amountX",
-            "docs": [
-              "Amount of X token to deposit"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "amountY",
-            "docs": [
-              "Amount of Y token to deposit"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "activeId",
-            "docs": [
-              "Active bin that integrator observe off-chain"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "maxActiveBinSlippage",
-            "docs": [
-              "max active bin slippage allowed"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "binLiquidityDist",
-            "docs": [
-              "Liquidity distribution to each bins"
-            ],
-            "type": {
-              "vec": {
-                "defined": "BinLiquidityDistributionByWeight"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "AddLiquiditySingleSidePreciseParameter",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "bins",
-            "type": {
-              "vec": {
-                "defined": "CompressedBinDepositAmount"
-              }
-            }
-          },
-          {
-            "name": "decompressMultiplier",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "CompressedBinDepositAmount",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "binId",
-            "type": "i32"
-          },
-          {
-            "name": "amount",
-            "type": "u32"
-          }
-        ]
-      }
-    },
-    {
-      "name": "BinLiquidityDistribution",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "binId",
-            "docs": [
-              "Define the bin ID wish to deposit to."
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "distributionX",
-            "docs": [
-              "DistributionX (or distributionY) is the percentages of amountX (or amountY) you want to add to each bin."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "distributionY",
-            "docs": [
-              "DistributionX (or distributionY) is the percentages of amountX (or amountY) you want to add to each bin."
-            ],
-            "type": "u16"
-          }
-        ]
-      }
-    },
-    {
-      "name": "LiquidityParameter",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "amountX",
-            "docs": [
-              "Amount of X token to deposit"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "amountY",
-            "docs": [
-              "Amount of Y token to deposit"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "binLiquidityDist",
-            "docs": [
-              "Liquidity distribution to each bins"
-            ],
-            "type": {
-              "vec": {
-                "defined": "BinLiquidityDistribution"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "CustomizableParams",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "activeId",
-            "docs": [
-              "Pool price"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "binStep",
-            "docs": [
-              "Bin step"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFactor",
-            "docs": [
-              "Base factor"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "activationType",
-            "docs": [
-              "Activation type. 0 = Slot, 1 = Time. Check ActivationType enum"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "hasAlphaVault",
-            "docs": [
-              "Whether the pool has an alpha vault"
-            ],
-            "type": "bool"
-          },
-          {
-            "name": "activationPoint",
-            "docs": [
-              "Decide when does the pool start trade. None = Now"
-            ],
-            "type": {
-              "option": "u64"
-            }
-          },
-          {
-            "name": "creatorPoolOnOffControl",
-            "docs": [
-              "Pool creator have permission to enable/disable pool with restricted program validation. Only applicable for customizable permissionless pool."
-            ],
-            "type": "bool"
-          },
-          {
-            "name": "baseFeePowerFactor",
-            "docs": [
-              "Base fee power factor"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "padding",
-            "docs": [
-              "Padding, for future use"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                62
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "InitPermissionPairIx",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "activeId",
-            "type": "i32"
-          },
-          {
-            "name": "binStep",
-            "type": "u16"
-          },
-          {
-            "name": "baseFactor",
-            "type": "u16"
-          },
-          {
-            "name": "baseFeePowerFactor",
-            "type": "u8"
-          },
-          {
-            "name": "activationType",
-            "type": "u8"
-          },
-          {
-            "name": "protocolShare",
-            "type": "u16"
-          }
-        ]
-      }
-    },
-    {
-      "name": "AddLiquiditySingleSidePreciseParameter2",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "bins",
-            "type": {
-              "vec": {
-                "defined": "CompressedBinDepositAmount"
-              }
-            }
-          },
-          {
-            "name": "decompressMultiplier",
-            "type": "u64"
-          },
-          {
-            "name": "maxAmount",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "CompressedBinDepositAmount2",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "binId",
-            "type": "i32"
-          },
-          {
-            "name": "amount",
-            "type": "u32"
-          }
-        ]
-      }
-    },
-    {
-      "name": "InitializeLbPair2Params",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "activeId",
-            "docs": [
-              "Pool price"
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "padding",
-            "docs": [
-              "Padding, for future use"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                96
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "BinLiquidityReduction",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "binId",
-            "type": "i32"
-          },
-          {
-            "name": "bpsToRemove",
-            "type": "u16"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Bin",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "amountX",
-            "docs": [
-              "Amount of token X in the bin. This already excluded protocol fees."
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "amountY",
-            "docs": [
-              "Amount of token Y in the bin. This already excluded protocol fees."
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "price",
-            "docs": [
-              "Bin price"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "liquiditySupply",
-            "docs": [
-              "Liquidities of the bin. This is the same as LP mint supply. q-number"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "rewardPerTokenStored",
-            "docs": [
-              "reward_a_per_token_stored"
-            ],
-            "type": {
-              "array": [
-                "u128",
-                2
-              ]
-            }
-          },
-          {
-            "name": "feeAmountXPerTokenStored",
-            "docs": [
-              "Swap fee amount of token X per liquidity deposited."
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "feeAmountYPerTokenStored",
-            "docs": [
-              "Swap fee amount of token Y per liquidity deposited."
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "amountXIn",
-            "docs": [
-              "Total token X swap into the bin. Only used for tracking purpose."
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "amountYIn",
-            "docs": [
-              "Total token Y swap into he bin. Only used for tracking purpose."
-            ],
-            "type": "u128"
-          }
-        ]
-      }
-    },
-    {
-      "name": "ProtocolFee",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "amountX",
-            "type": "u64"
-          },
-          {
-            "name": "amountY",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "RewardInfo",
-      "docs": [
-        "Stores the state relevant for tracking liquidity mining rewards"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "mint",
-            "docs": [
-              "Reward token mint."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "vault",
-            "docs": [
-              "Reward vault token account."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "funder",
-            "docs": [
-              "Authority account that allows to fund rewards"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "rewardDuration",
-            "docs": [
-              "TODO check whether we need to store it in pool"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "rewardDurationEnd",
-            "docs": [
-              "TODO check whether we need to store it in pool"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "rewardRate",
-            "docs": [
-              "TODO check whether we need to store it in pool"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "lastUpdateTime",
-            "docs": [
-              "The last time reward states were updated."
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "cumulativeSecondsWithEmptyLiquidityReward",
-            "docs": [
-              "Accumulated seconds where when farm distribute rewards, but the bin is empty. The reward will be accumulated for next reward time window."
-            ],
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Observation",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "cumulativeActiveBinId",
-            "docs": [
-              "Cumulative active bin ID"
-            ],
-            "type": "i128"
-          },
-          {
-            "name": "createdAt",
-            "docs": [
-              "Observation sample created timestamp"
-            ],
-            "type": "i64"
-          },
-          {
-            "name": "lastUpdatedAt",
-            "docs": [
-              "Observation sample last updated timestamp"
-            ],
-            "type": "i64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "StaticParameters",
-      "docs": [
-        "Parameter that set by the protocol"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "baseFactor",
-            "docs": [
-              "Used for base fee calculation. base_fee_rate = base_factor * bin_step * 10 * 10^base_fee_power_factor"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "filterPeriod",
-            "docs": [
-              "Filter period determine high frequency trading time window."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "decayPeriod",
-            "docs": [
-              "Decay period determine when the volatile fee start decay / decrease."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "reductionFactor",
-            "docs": [
-              "Reduction factor controls the volatile fee rate decrement rate."
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "variableFeeControl",
-            "docs": [
-              "Used to scale the variable fee component depending on the dynamic of the market"
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "maxVolatilityAccumulator",
-            "docs": [
-              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "minBinId",
-            "docs": [
-              "Min bin id supported by the pool based on the configured bin step."
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "maxBinId",
-            "docs": [
-              "Max bin id supported by the pool based on the configured bin step."
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "protocolShare",
-            "docs": [
-              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "baseFeePowerFactor",
-            "docs": [
-              "Base fee power factor"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "padding",
-            "docs": [
-              "Padding for bytemuck safe alignment"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                5
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "VariableParameters",
-      "docs": [
-        "Parameters that changes based on dynamic of the market"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "volatilityAccumulator",
-            "docs": [
-              "Volatility accumulator measure the number of bin crossed since reference bin ID. Normally (without filter period taken into consideration), reference bin ID is the active bin of last swap.",
-              "It affects the variable fee rate"
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "volatilityReference",
-            "docs": [
-              "Volatility reference is decayed volatility accumulator. It is always <= volatility_accumulator"
-            ],
-            "type": "u32"
-          },
-          {
-            "name": "indexReference",
-            "docs": [
-              "Active bin id of last swap."
-            ],
-            "type": "i32"
-          },
-          {
-            "name": "padding",
-            "docs": [
-              "Padding for bytemuck safe alignment"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                4
-              ]
-            }
-          },
-          {
-            "name": "lastUpdateTimestamp",
-            "docs": [
-              "Last timestamp the variable parameters was updated"
-            ],
-            "type": "i64"
-          },
-          {
-            "name": "padding1",
-            "docs": [
-              "Padding for bytemuck safe alignment"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                8
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "FeeInfo",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "feeXPerTokenComplete",
-            "type": "u128"
-          },
-          {
-            "name": "feeYPerTokenComplete",
-            "type": "u128"
-          },
-          {
-            "name": "feeXPending",
-            "type": "u64"
-          },
-          {
-            "name": "feeYPending",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "UserRewardInfo",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "rewardPerTokenCompletes",
-            "type": {
-              "array": [
-                "u128",
-                2
-              ]
-            }
-          },
-          {
-            "name": "rewardPendings",
-            "type": {
-              "array": [
-                "u64",
-                2
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "RemainingAccountsSlice",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "accountsType",
-            "type": {
-              "defined": "AccountsType"
-            }
-          },
-          {
-            "name": "length",
-            "type": "u8"
-          }
-        ]
-      }
-    },
-    {
-      "name": "RemainingAccountsInfo",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "slices",
-            "type": {
-              "vec": {
-                "defined": "RemainingAccountsSlice"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "StrategyType",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "SpotOneSide"
-          },
-          {
-            "name": "CurveOneSide"
-          },
-          {
-            "name": "BidAskOneSide"
-          },
-          {
-            "name": "SpotBalanced"
-          },
-          {
-            "name": "CurveBalanced"
-          },
-          {
-            "name": "BidAskBalanced"
-          },
-          {
-            "name": "SpotImBalanced"
-          },
-          {
-            "name": "CurveImBalanced"
-          },
-          {
-            "name": "BidAskImBalanced"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Rounding",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Up"
-          },
-          {
-            "name": "Down"
-          }
-        ]
-      }
-    },
-    {
-      "name": "ActivationType",
-      "docs": [
-        "Type of the activation"
-      ],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Slot"
-          },
-          {
-            "name": "Timestamp"
-          }
-        ]
-      }
-    },
-    {
-      "name": "LayoutVersion",
-      "docs": [
-        "Layout version"
-      ],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "V0"
-          },
-          {
-            "name": "V1"
-          }
-        ]
-      }
-    },
-    {
-      "name": "PairType",
-      "docs": [
-        "Type of the Pair. 0 = Permissionless, 1 = Permission, 2 = CustomizablePermissionless. Putting 0 as permissionless for backward compatibility."
-      ],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Permissionless"
-          },
-          {
-            "name": "Permission"
-          },
-          {
-            "name": "CustomizablePermissionless"
-          },
-          {
-            "name": "PermissionlessV2"
-          }
-        ]
-      }
-    },
-    {
-      "name": "PairStatus",
-      "docs": [
-        "Pair status. 0 = Enabled, 1 = Disabled. Putting 0 as enabled for backward compatibility."
-      ],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Enabled"
-          },
-          {
-            "name": "Disabled"
-          }
-        ]
-      }
-    },
-    {
-      "name": "TokenProgramFlags",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "TokenProgram"
-          },
-          {
-            "name": "TokenProgram2022"
-          }
-        ]
-      }
-    },
-    {
-      "name": "AccountsType",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "TransferHookX"
-          },
-          {
-            "name": "TransferHookY"
-          },
-          {
-            "name": "TransferHookReward"
-          }
-        ]
-      }
+      "discriminator": [116, 219, 204, 229, 249, 116, 255, 150]
     }
   ],
   "events": [
     {
-      "name": "CompositionFee",
-      "fields": [
-        {
-          "name": "from",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "binId",
-          "type": "i16",
-          "index": false
-        },
-        {
-          "name": "tokenXFeeAmount",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "tokenYFeeAmount",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "protocolTokenXFeeAmount",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "protocolTokenYFeeAmount",
-          "type": "u64",
-          "index": false
-        }
-      ]
-    },
-    {
       "name": "AddLiquidity",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "from",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "amounts",
-          "type": {
-            "array": [
-              "u64",
-              2
-            ]
-          },
-          "index": false
-        },
-        {
-          "name": "activeBinId",
-          "type": "i32",
-          "index": false
-        }
-      ]
+      "discriminator": [31, 94, 125, 90, 227, 52, 61, 186]
     },
     {
-      "name": "RemoveLiquidity",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "from",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "amounts",
-          "type": {
-            "array": [
-              "u64",
-              2
-            ]
-          },
-          "index": false
-        },
-        {
-          "name": "activeBinId",
-          "type": "i32",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "Swap",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "from",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "startBinId",
-          "type": "i32",
-          "index": false
-        },
-        {
-          "name": "endBinId",
-          "type": "i32",
-          "index": false
-        },
-        {
-          "name": "amountIn",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "amountOut",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "swapForY",
-          "type": "bool",
-          "index": false
-        },
-        {
-          "name": "fee",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "protocolFee",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "feeBps",
-          "type": "u128",
-          "index": false
-        },
-        {
-          "name": "hostFee",
-          "type": "u64",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "ClaimReward",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "owner",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "rewardIndex",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "totalReward",
-          "type": "u64",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "FundReward",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "funder",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "rewardIndex",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "amount",
-          "type": "u64",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "InitializeReward",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "rewardMint",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "funder",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "rewardIndex",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "rewardDuration",
-          "type": "u64",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "UpdateRewardDuration",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "rewardIndex",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "oldRewardDuration",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "newRewardDuration",
-          "type": "u64",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "UpdateRewardFunder",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "rewardIndex",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "oldFunder",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "newFunder",
-          "type": "publicKey",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "PositionClose",
-      "fields": [
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "owner",
-          "type": "publicKey",
-          "index": false
-        }
-      ]
+      "name": "CancelLimitOrderEvt",
+      "discriminator": [131, 234, 194, 133, 9, 14, 189, 209]
     },
     {
       "name": "ClaimFee",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "owner",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "feeX",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "feeY",
-          "type": "u64",
-          "index": false
-        }
-      ]
+      "discriminator": [75, 122, 154, 48, 140, 74, 123, 163]
     },
     {
-      "name": "LbPairCreate",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "binStep",
-          "type": "u16",
-          "index": false
-        },
-        {
-          "name": "tokenX",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "tokenY",
-          "type": "publicKey",
-          "index": false
-        }
-      ]
+      "name": "ClaimFee2",
+      "discriminator": [232, 171, 242, 97, 58, 77, 35, 45]
     },
     {
-      "name": "PositionCreate",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "owner",
-          "type": "publicKey",
-          "index": false
-        }
-      ]
+      "name": "ClaimReward",
+      "discriminator": [148, 116, 134, 204, 22, 171, 85, 95]
     },
     {
-      "name": "IncreasePositionLength",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "owner",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "lengthToAdd",
-          "type": "u16",
-          "index": false
-        },
-        {
-          "name": "side",
-          "type": "u8",
-          "index": false
-        }
-      ]
+      "name": "ClaimReward2",
+      "discriminator": [27, 143, 244, 33, 80, 43, 110, 146]
+    },
+    {
+      "name": "CloseLimitOrderEvt",
+      "discriminator": [142, 135, 8, 76, 92, 63, 118, 83]
+    },
+    {
+      "name": "CompositionFee",
+      "discriminator": [128, 151, 123, 106, 17, 102, 113, 142]
     },
     {
       "name": "DecreasePositionLength",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "owner",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "lengthToRemove",
-          "type": "u16",
-          "index": false
-        },
-        {
-          "name": "side",
-          "type": "u8",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "FeeParameterUpdate",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "protocolShare",
-          "type": "u16",
-          "index": false
-        },
-        {
-          "name": "baseFactor",
-          "type": "u16",
-          "index": false
-        }
-      ]
+      "discriminator": [52, 118, 235, 85, 172, 169, 15, 128]
     },
     {
       "name": "DynamicFeeParameterUpdate",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "filterPeriod",
-          "type": "u16",
-          "index": false
-        },
-        {
-          "name": "decayPeriod",
-          "type": "u16",
-          "index": false
-        },
-        {
-          "name": "reductionFactor",
-          "type": "u16",
-          "index": false
-        },
-        {
-          "name": "variableFeeControl",
-          "type": "u32",
-          "index": false
-        },
-        {
-          "name": "maxVolatilityAccumulator",
-          "type": "u32",
-          "index": false
-        }
-      ]
+      "discriminator": [88, 88, 178, 135, 194, 146, 91, 243]
     },
     {
-      "name": "IncreaseObservation",
-      "fields": [
-        {
-          "name": "oracle",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "newObservationLength",
-          "type": "u64",
-          "index": false
-        }
-      ]
+      "name": "FeeParameterUpdate",
+      "discriminator": [48, 76, 241, 117, 144, 215, 242, 44]
     },
     {
-      "name": "WithdrawIneligibleReward",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "rewardMint",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "amount",
-          "type": "u64",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "UpdatePositionOperator",
-      "fields": [
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "oldOperator",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "newOperator",
-          "type": "publicKey",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "UpdatePositionLockReleasePoint",
-      "fields": [
-        {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "currentPoint",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "newLockReleasePoint",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "oldLockReleasePoint",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "sender",
-          "type": "publicKey",
-          "index": false
-        }
-      ]
+      "name": "FundReward",
+      "discriminator": [246, 228, 58, 130, 145, 170, 79, 204]
     },
     {
       "name": "GoToABin",
-      "fields": [
-        {
-          "name": "lbPair",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "fromBinId",
-          "type": "i32",
-          "index": false
-        },
-        {
-          "name": "toBinId",
-          "type": "i32",
-          "index": false
-        }
-      ]
+      "discriminator": [59, 138, 76, 68, 138, 131, 176, 67]
+    },
+    {
+      "name": "IncreaseObservation",
+      "discriminator": [99, 249, 17, 121, 166, 156, 207, 215]
+    },
+    {
+      "name": "IncreasePositionLength",
+      "discriminator": [157, 239, 42, 204, 30, 56, 223, 46]
+    },
+    {
+      "name": "InitializeReward",
+      "discriminator": [211, 153, 88, 62, 149, 60, 177, 70]
+    },
+    {
+      "name": "LbPairCreate",
+      "discriminator": [185, 74, 252, 125, 27, 215, 188, 111]
+    },
+    {
+      "name": "PlaceLimitOrderEvt",
+      "discriminator": [43, 79, 27, 169, 244, 28, 225, 63]
+    },
+    {
+      "name": "PositionClose",
+      "discriminator": [255, 196, 16, 107, 28, 202, 53, 128]
+    },
+    {
+      "name": "PositionCreate",
+      "discriminator": [144, 142, 252, 84, 157, 53, 37, 121]
+    },
+    {
+      "name": "Rebalancing",
+      "discriminator": [0, 109, 117, 179, 61, 91, 199, 200]
+    },
+    {
+      "name": "RemoveLiquidity",
+      "discriminator": [116, 244, 97, 232, 103, 31, 152, 58]
+    },
+    {
+      "name": "SetPositionPermissionlessOperationBitsEvt",
+      "discriminator": [195, 229, 147, 245, 29, 125, 48, 168]
+    },
+    {
+      "name": "Swap",
+      "discriminator": [81, 108, 227, 190, 205, 208, 10, 196]
+    },
+    {
+      "name": "Swap2Evt",
+      "discriminator": [46, 116, 82, 215, 148, 27, 84, 77]
+    },
+    {
+      "name": "UpdatePositionLockReleasePoint",
+      "discriminator": [133, 214, 66, 224, 64, 12, 7, 191]
+    },
+    {
+      "name": "UpdatePositionOperator",
+      "discriminator": [39, 115, 48, 204, 246, 47, 66, 57]
+    },
+    {
+      "name": "UpdateRewardDuration",
+      "discriminator": [223, 245, 224, 153, 49, 29, 163, 172]
+    },
+    {
+      "name": "UpdateRewardFunder",
+      "discriminator": [224, 178, 174, 74, 252, 165, 85, 180]
+    },
+    {
+      "name": "WithdrawIneligibleReward",
+      "discriminator": [231, 189, 65, 149, 102, 215, 154, 244]
     }
   ],
   "errors": [
@@ -7364,6 +5633,3599 @@
       "code": 6082,
       "name": "NotSupportAtTheMoment",
       "msg": "Not support at the moment"
+    },
+    {
+      "code": 6083,
+      "name": "InvalidRebalanceParameters",
+      "msg": "Invalid rebalance parameters"
+    },
+    {
+      "code": 6084,
+      "name": "InvalidRewardAccounts",
+      "msg": "Invalid reward accounts"
+    },
+    {
+      "code": 6085,
+      "name": "UndeterminedError",
+      "msg": "Undetermined error"
+    },
+    {
+      "code": 6086,
+      "name": "ReallocExceedMaxLengthPerInstruction",
+      "msg": "Realloc exceed max length per instruction"
+    },
+    {
+      "code": 6087,
+      "name": "InvalidBaseFeeMantissa",
+      "msg": "Mantissa cannot more than two significant digits"
+    },
+    {
+      "code": 6088,
+      "name": "InvalidPositionOwner",
+      "msg": "Invalid position owner"
+    },
+    {
+      "code": 6089,
+      "name": "InvalidPoolAddress",
+      "msg": "Invalid pool address"
+    },
+    {
+      "code": 6090,
+      "name": "InvalidTokenBadgeType",
+      "msg": "Invalid token badge type"
+    },
+    {
+      "code": 6091,
+      "name": "InvalidTransferHookAuthority",
+      "msg": "Invalid transfer hook authority"
+    },
+    {
+      "code": 6092,
+      "name": "AmountXIsNegative",
+      "msg": "Amount x is negative"
+    },
+    {
+      "code": 6093,
+      "name": "AmountYIsNegative",
+      "msg": "Amount y is negative"
+    },
+    {
+      "code": 6094,
+      "name": "InvalidPoolCreator",
+      "msg": "Invalid pool creator"
+    },
+    {
+      "code": 6095,
+      "name": "InvalidFunctionType",
+      "msg": "Invalid function type"
+    },
+    {
+      "code": 6096,
+      "name": "InvalidPermission",
+      "msg": "Invalid permission"
+    },
+    {
+      "code": 6097,
+      "name": "IncorrectATA",
+      "msg": "Incorrect ATA"
+    },
+    {
+      "code": 6098,
+      "name": "InvalidWithdrawProtocolFeeZapAccounts",
+      "msg": "Invalid withdraw protocol fee zap accounts"
+    },
+    {
+      "code": 6099,
+      "name": "MintRestrictedFromZap",
+      "msg": "SOL,USDC protocol fee cannot be withdrawn via zap"
+    },
+    {
+      "code": 6100,
+      "name": "CpiDisabled",
+      "msg": "CPI disabled"
+    },
+    {
+      "code": 6101,
+      "name": "MissingZapOutInstruction",
+      "msg": "Missing zap out instruction"
+    },
+    {
+      "code": 6102,
+      "name": "InvalidZapAccounts",
+      "msg": "Invalid zap accounts"
+    },
+    {
+      "code": 6103,
+      "name": "InvalidZapOutParameters",
+      "msg": "Invalid zap out parameters"
+    },
+    {
+      "code": 6104,
+      "name": "InsufficientInAmount",
+      "msg": "Insufficient in amount"
+    },
+    {
+      "code": 6105,
+      "name": "InvalidPlaceLimitOrderParameters",
+      "msg": "Invalid place limit order parameters"
+    },
+    {
+      "code": 6106,
+      "name": "InvalidLimitOrderOwner",
+      "msg": "Invalid limit order owner"
+    },
+    {
+      "code": 6107,
+      "name": "InvalidCancelLimitOrderParameters",
+      "msg": "Invalid cancel limit order parameters"
+    },
+    {
+      "code": 6108,
+      "name": "CannotFindLimitOrderByBinId",
+      "msg": "Cannot find limit order by bin id"
+    },
+    {
+      "code": 6109,
+      "name": "CancelNonEmptyLimitOrder",
+      "msg": "Cannot cancel non-empty limit order"
+    },
+    {
+      "code": 6110,
+      "name": "InvalidCollectFeeMode",
+      "msg": "Invalid collect fee mode"
+    }
+  ],
+  "types": [
+    {
+      "name": "AccountsType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "TransferHookX"
+          },
+          {
+            "name": "TransferHookY"
+          },
+          {
+            "name": "TransferHookReward"
+          },
+          {
+            "name": "TransferHookMultiReward",
+            "fields": ["u8"]
+          },
+          {
+            "name": "TransferHookReferral"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ActivationType",
+      "docs": ["Type of the activation"],
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Slot"
+          },
+          {
+            "name": "Timestamp"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AddLiquidity",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "from",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "amounts",
+            "type": {
+              "array": ["u64", 2]
+            }
+          },
+          {
+            "name": "active_bin_id",
+            "type": "i32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AddLiquidityParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "min_delta_id",
+            "type": "i32"
+          },
+          {
+            "name": "max_delta_id",
+            "type": "i32"
+          },
+          {
+            "name": "x0",
+            "type": "u64"
+          },
+          {
+            "name": "y0",
+            "type": "u64"
+          },
+          {
+            "name": "delta_x",
+            "type": "u64"
+          },
+          {
+            "name": "delta_y",
+            "type": "u64"
+          },
+          {
+            "name": "bit_flag",
+            "type": "u8"
+          },
+          {
+            "name": "favor_x_in_active_id",
+            "type": "bool"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": ["u8", 16]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "AddLiquiditySingleSidePreciseParameter",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bins",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "CompressedBinDepositAmount"
+                }
+              }
+            }
+          },
+          {
+            "name": "decompress_multiplier",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AddLiquiditySingleSidePreciseParameter2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bins",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "CompressedBinDepositAmount"
+                }
+              }
+            }
+          },
+          {
+            "name": "decompress_multiplier",
+            "type": "u64"
+          },
+          {
+            "name": "max_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BaseFeeParameter",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "protocol_share",
+            "docs": [
+              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "base_factor",
+            "docs": ["Base factor for base fee rate"],
+            "type": "u16"
+          },
+          {
+            "name": "base_fee_power_factor",
+            "docs": ["Base fee power factor"],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Bin",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_x",
+            "docs": [
+              "Amount of token X in the bin for market making. This already excluded protocol fees."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "amount_y",
+            "docs": [
+              "Amount of token Y in the bin for market making. This already excluded protocol fees."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "price",
+            "docs": ["Bin price"],
+            "type": "u128"
+          },
+          {
+            "name": "liquidity_supply",
+            "docs": ["Bin MM liquidity supply."],
+            "type": "u128"
+          },
+          {
+            "name": "fulfilled_order_amount_x",
+            "docs": ["Total fulfilled order amount x"],
+            "type": "u64"
+          },
+          {
+            "name": "fulfilled_order_amount_y",
+            "docs": ["Total fulfilled order amount y"],
+            "type": "u64"
+          },
+          {
+            "name": "limit_order_fee_ask_side",
+            "docs": ["Limit order fee collected by ask side orders"],
+            "type": "u64"
+          },
+          {
+            "name": "limit_order_fee_bid_side",
+            "docs": ["Limit order fee collected by bid side orders"],
+            "type": "u64"
+          },
+          {
+            "name": "fee_amount_x_per_token_stored",
+            "docs": ["Swap fee amount of token X per liquidity deposited."],
+            "type": "u128"
+          },
+          {
+            "name": "fee_amount_y_per_token_stored",
+            "docs": ["Swap fee amount of token Y per liquidity deposited."],
+            "type": "u128"
+          },
+          {
+            "name": "open_order_amount",
+            "docs": ["Pending open limit orders amount in the bin."],
+            "type": "u64"
+          },
+          {
+            "name": "total_processing_order_amount",
+            "docs": ["Total processing order amount"],
+            "type": "u64"
+          },
+          {
+            "name": "processed_order_remaining_amount",
+            "docs": [
+              "Remaining in processing open limit orders amount in the bin."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "order_age",
+            "docs": ["Age"],
+            "type": "u32"
+          },
+          {
+            "name": "limit_order_ask_side",
+            "docs": ["limit order flag"],
+            "type": "u8"
+          },
+          {
+            "name": "_padding_1",
+            "docs": ["padding"],
+            "type": {
+              "array": ["u8", 3]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BinArray",
+      "docs": [
+        "An account to contain a range of bin. For example: Bin 100 <-> 200.",
+        "For example:",
+        "BinArray index: 0 contains bin 0 <-> 599",
+        "index: 2 contains bin 600 <-> 1199, ..."
+      ],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "index",
+            "type": "i64"
+          },
+          {
+            "name": "version",
+            "type": "u8"
+          },
+          {
+            "name": "_padding_1",
+            "type": {
+              "array": ["u8", 7]
+            }
+          },
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "bins",
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "Bin"
+                  }
+                },
+                70
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BinArrayBitmapExtension",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "positive_bin_array_bitmap",
+            "docs": [
+              "Packed initialized bin array state for start_bin_index is positive"
+            ],
+            "type": {
+              "array": [
+                {
+                  "array": ["u64", 8]
+                },
+                12
+              ]
+            }
+          },
+          {
+            "name": "negative_bin_array_bitmap",
+            "docs": [
+              "Packed initialized bin array state for start_bin_index is negative"
+            ],
+            "type": {
+              "array": [
+                {
+                  "array": ["u64", 8]
+                },
+                12
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BinLimitOrderAmount",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "id",
+            "type": "i32"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BinLiquidityDistribution",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bin_id",
+            "docs": ["Define the bin ID wish to deposit to."],
+            "type": "i32"
+          },
+          {
+            "name": "distribution_x",
+            "docs": [
+              "DistributionX (or distributionY) is the percentages of amountX (or amountY) you want to add to each bin."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "distribution_y",
+            "docs": [
+              "DistributionX (or distributionY) is the percentages of amountX (or amountY) you want to add to each bin."
+            ],
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BinLiquidityDistributionByWeight",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bin_id",
+            "docs": ["Define the bin ID wish to deposit to."],
+            "type": "i32"
+          },
+          {
+            "name": "weight",
+            "docs": ["weight of liquidity distributed for this bin id"],
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BinLiquidityReduction",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bin_id",
+            "type": "i32"
+          },
+          {
+            "name": "bps_to_remove",
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CancelLimitOrderEvt",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "from",
+            "type": "pubkey"
+          },
+          {
+            "name": "limit_order",
+            "type": "pubkey"
+          },
+          {
+            "name": "amounts",
+            "type": {
+              "array": ["u64", 2]
+            }
+          },
+          {
+            "name": "active_id",
+            "type": "i32"
+          },
+          {
+            "name": "bins",
+            "type": {
+              "vec": "i32"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ClaimFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_x",
+            "type": "u64"
+          },
+          {
+            "name": "fee_y",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ClaimFee2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_x",
+            "type": "u64"
+          },
+          {
+            "name": "fee_y",
+            "type": "u64"
+          },
+          {
+            "name": "active_bin_id",
+            "type": "i32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ClaimFeeOperator",
+      "docs": ["Parameter that set by the protocol"],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "operator",
+            "docs": ["operator"],
+            "type": "pubkey"
+          },
+          {
+            "name": "_padding",
+            "docs": ["Reserve"],
+            "type": {
+              "array": ["u8", 128]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ClaimReward",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_index",
+            "type": "u64"
+          },
+          {
+            "name": "total_reward",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ClaimReward2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_index",
+            "type": "u64"
+          },
+          {
+            "name": "total_reward",
+            "type": "u64"
+          },
+          {
+            "name": "active_bin_id",
+            "type": "i32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CloseLimitOrderEvt",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "limit_order",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CompositionFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "from",
+            "type": "pubkey"
+          },
+          {
+            "name": "bin_id",
+            "type": "i16"
+          },
+          {
+            "name": "token_x_fee_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_y_fee_amount",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_token_x_fee_amount",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_token_y_fee_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CompressedBinDepositAmount",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bin_id",
+            "type": "i32"
+          },
+          {
+            "name": "amount",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CustomizableParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "active_id",
+            "docs": ["Pool price"],
+            "type": "i32"
+          },
+          {
+            "name": "bin_step",
+            "docs": ["Bin step"],
+            "type": "u16"
+          },
+          {
+            "name": "base_factor",
+            "docs": ["Base factor"],
+            "type": "u16"
+          },
+          {
+            "name": "activation_type",
+            "docs": [
+              "Activation type. 0 = Slot, 1 = Time. Check ActivationType enum"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "has_alpha_vault",
+            "docs": ["Whether the pool has an alpha vault"],
+            "type": "bool"
+          },
+          {
+            "name": "activation_point",
+            "docs": ["Decide when does the pool start trade. None = Now"],
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "creator_pool_on_off_control",
+            "docs": [
+              "Pool creator have permission to enable/disable pool with restricted program validation. Only applicable for customizable permissionless pool."
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "base_fee_power_factor",
+            "docs": ["Base fee power factor"],
+            "type": "u8"
+          },
+          {
+            "name": "concrete_function_type",
+            "docs": ["Concrete function type"],
+            "type": "u8"
+          },
+          {
+            "name": "collect_fee_mode",
+            "docs": ["Collect fee mode"],
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "docs": ["Padding, for future use"],
+            "type": {
+              "array": ["u8", 60]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "DecreasePositionLength",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "length_to_remove",
+            "type": "u16"
+          },
+          {
+            "name": "side",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DummyIx",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "_pair_status",
+            "type": {
+              "defined": {
+                "name": "PairStatus"
+              }
+            }
+          },
+          {
+            "name": "_pair_type",
+            "type": {
+              "defined": {
+                "name": "PairType"
+              }
+            }
+          },
+          {
+            "name": "_activation_type",
+            "type": {
+              "defined": {
+                "name": "ActivationType"
+              }
+            }
+          },
+          {
+            "name": "_token_program_flag",
+            "type": {
+              "defined": {
+                "name": "TokenProgramFlags"
+              }
+            }
+          },
+          {
+            "name": "_resize_side",
+            "type": {
+              "defined": {
+                "name": "ResizeSide"
+              }
+            }
+          },
+          {
+            "name": "_rounding",
+            "type": {
+              "defined": {
+                "name": "Rounding"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "DummyZcAccount",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "position_bin_data",
+            "type": {
+              "defined": {
+                "name": "PositionBinData"
+              }
+            }
+          },
+          {
+            "name": "limit_order_bin_data",
+            "type": {
+              "defined": {
+                "name": "LimitOrderBinData"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "DynamicFeeParameter",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "filter_period",
+            "docs": [
+              "Filter period determine high frequency trading time window."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "docs": [
+              "Decay period determine when the volatile fee start decay / decrease."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "docs": [
+              "Reduction factor controls the volatile fee rate decrement rate."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "variable_fee_control",
+            "docs": [
+              "Used to scale the variable fee component depending on the dynamic of the market"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "docs": [
+              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
+            ],
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DynamicFeeParameterUpdate",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "filter_period",
+            "docs": [
+              "Filter period determine high frequency trading time window."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "docs": [
+              "Decay period determine when the volatile fee start decay / decrease."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "docs": [
+              "Reduction factor controls the volatile fee rate decrement rate."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "variable_fee_control",
+            "docs": [
+              "Used to scale the variable fee component depending on the dynamic of the market"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "docs": [
+              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
+            ],
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FeeInfo",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "fee_x_per_token_complete",
+            "type": "u128"
+          },
+          {
+            "name": "fee_y_per_token_complete",
+            "type": "u128"
+          },
+          {
+            "name": "fee_x_pending",
+            "type": "u64"
+          },
+          {
+            "name": "fee_y_pending",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FeeParameterUpdate",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "protocol_share",
+            "type": "u16"
+          },
+          {
+            "name": "base_factor",
+            "type": "u16"
+          },
+          {
+            "name": "base_fee_power_factor",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FundReward",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "funder",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_index",
+            "type": "u64"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "GoToABin",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "from_bin_id",
+            "type": "i32"
+          },
+          {
+            "name": "to_bin_id",
+            "type": "i32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "IncreaseObservation",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "oracle",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_observation_length",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "IncreasePositionLength",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "length_to_add",
+            "type": "u16"
+          },
+          {
+            "name": "side",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "InitPermissionPairIx",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "active_id",
+            "type": "i32"
+          },
+          {
+            "name": "bin_step",
+            "type": "u16"
+          },
+          {
+            "name": "base_factor",
+            "type": "u16"
+          },
+          {
+            "name": "base_fee_power_factor",
+            "type": "u8"
+          },
+          {
+            "name": "activation_type",
+            "type": "u8"
+          },
+          {
+            "name": "padding0",
+            "type": "u16"
+          },
+          {
+            "name": "concrete_function_type",
+            "type": "u8"
+          },
+          {
+            "name": "collect_fee_mode",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "InitPresetParametersIx",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "index",
+            "type": "u16"
+          },
+          {
+            "name": "bin_step",
+            "docs": ["Bin step. Represent the price increment / decrement."],
+            "type": "u16"
+          },
+          {
+            "name": "base_factor",
+            "docs": [
+              "Used for base fee calculation. base_fee_rate = base_factor * bin_step * 10 * 10^base_fee_power_factor"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "filter_period",
+            "docs": [
+              "Filter period determine high frequency trading time window."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "docs": [
+              "Decay period determine when the volatile fee start decay / decrease."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "docs": [
+              "Reduction factor controls the volatile fee rate decrement rate."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "variable_fee_control",
+            "docs": [
+              "Used to scale the variable fee component depending on the dynamic of the market"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "docs": [
+              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "protocol_share",
+            "docs": [
+              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "base_fee_power_factor",
+            "docs": ["Base fee power factor"],
+            "type": "u8"
+          },
+          {
+            "name": "concrete_function_type",
+            "docs": ["function type"],
+            "type": "u8"
+          },
+          {
+            "name": "collect_fee_mode",
+            "docs": ["collect fee mode"],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "InitializeLbPair2Params",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "active_id",
+            "docs": ["Pool price"],
+            "type": "i32"
+          },
+          {
+            "name": "padding",
+            "docs": ["Padding, for future use"],
+            "type": {
+              "array": ["u8", 96]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "InitializeReward",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "funder",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_index",
+            "type": "u64"
+          },
+          {
+            "name": "reward_duration",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LbPair",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "parameters",
+            "type": {
+              "defined": {
+                "name": "StaticParameters"
+              }
+            }
+          },
+          {
+            "name": "v_parameters",
+            "type": {
+              "defined": {
+                "name": "VariableParameters"
+              }
+            }
+          },
+          {
+            "name": "bump_seed",
+            "type": {
+              "array": ["u8", 1]
+            }
+          },
+          {
+            "name": "bin_step_seed",
+            "docs": ["Bin step signer seed"],
+            "type": {
+              "array": ["u8", 2]
+            }
+          },
+          {
+            "name": "pair_type",
+            "docs": ["Type of the pair"],
+            "type": "u8"
+          },
+          {
+            "name": "active_id",
+            "docs": ["Active bin id"],
+            "type": "i32"
+          },
+          {
+            "name": "bin_step",
+            "docs": ["Bin step. Represent the price increment / decrement."],
+            "type": "u16"
+          },
+          {
+            "name": "status",
+            "docs": ["Status of the pair. Check PairStatus enum."],
+            "type": "u8"
+          },
+          {
+            "name": "require_base_factor_seed",
+            "docs": ["Require base factor seed"],
+            "type": "u8"
+          },
+          {
+            "name": "base_factor_seed",
+            "docs": ["Base factor seed"],
+            "type": {
+              "array": ["u8", 2]
+            }
+          },
+          {
+            "name": "activation_type",
+            "docs": ["Activation type"],
+            "type": "u8"
+          },
+          {
+            "name": "creator_pool_on_off_control",
+            "docs": [
+              "Allow pool creator to enable/disable pool with restricted validation. Only applicable for customizable permissionless pair type."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "token_x_mint",
+            "docs": ["Token X mint"],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_y_mint",
+            "docs": ["Token Y mint"],
+            "type": "pubkey"
+          },
+          {
+            "name": "reserve_x",
+            "docs": ["LB token X vault"],
+            "type": "pubkey"
+          },
+          {
+            "name": "reserve_y",
+            "docs": ["LB token Y vault"],
+            "type": "pubkey"
+          },
+          {
+            "name": "protocol_fee",
+            "docs": ["Uncollected protocol fee"],
+            "type": {
+              "defined": {
+                "name": "ProtocolFee"
+              }
+            }
+          },
+          {
+            "name": "_padding_1",
+            "docs": ["padding 1"],
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "reward_infos",
+            "docs": ["Farming reward information"],
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "RewardInfo"
+                  }
+                },
+                2
+              ]
+            }
+          },
+          {
+            "name": "oracle",
+            "docs": ["Oracle pubkey"],
+            "type": "pubkey"
+          },
+          {
+            "name": "bin_array_bitmap",
+            "docs": ["Packed initialized bin array state"],
+            "type": {
+              "array": ["u64", 16]
+            }
+          },
+          {
+            "name": "last_updated_at",
+            "docs": ["Last time the pool fee parameter was updated"],
+            "type": "i64"
+          },
+          {
+            "name": "_padding_2",
+            "docs": ["_padding_2"],
+            "type": {
+              "array": ["u8", 32]
+            }
+          },
+          {
+            "name": "pre_activation_swap_address",
+            "docs": [
+              "Address allowed to swap when the current point is greater than or equal to the pre-activation point. The pre-activation point is calculated as `activation_point - pre_activation_duration`."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "base_key",
+            "docs": ["Base keypair. Only required for permission pair"],
+            "type": "pubkey"
+          },
+          {
+            "name": "activation_point",
+            "docs": [
+              "Time point to enable the pair. Only applicable for permission pair."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "pre_activation_duration",
+            "docs": [
+              "Duration before activation activation_point. Used to calculate pre-activation time point for pre_activation_swap_address"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "_padding_3",
+            "docs": ["_padding 3"],
+            "type": {
+              "array": ["u8", 8]
+            }
+          },
+          {
+            "name": "_padding_4",
+            "docs": ["_padding_4"],
+            "type": "u64"
+          },
+          {
+            "name": "creator",
+            "docs": ["Pool creator"],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_mint_x_program_flag",
+            "docs": ["token_mint_x_program_flag"],
+            "type": "u8"
+          },
+          {
+            "name": "token_mint_y_program_flag",
+            "docs": ["token_mint_y_program_flag"],
+            "type": "u8"
+          },
+          {
+            "name": "version",
+            "docs": ["version to know whether we have reset tombstone fields"],
+            "type": "u8"
+          },
+          {
+            "name": "_reserved",
+            "docs": ["Reserved space for future use"],
+            "type": {
+              "array": ["u8", 21]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LbPairCreate",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "bin_step",
+            "type": "u16"
+          },
+          {
+            "name": "token_x",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_y",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LimitOrder",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "docs": ["The LB pair of this LO"],
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "docs": [
+              "Owner of the LO. Client rely on this to to fetch their LOs."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "bin_count",
+            "docs": ["Bin count"],
+            "type": "u16"
+          },
+          {
+            "name": "_padding_0",
+            "docs": ["Padding"],
+            "type": {
+              "array": ["u8", 14]
+            }
+          },
+          {
+            "name": "padding_1",
+            "docs": ["Reserved space for future use"],
+            "type": {
+              "array": ["u64", 4]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LimitOrderBinData",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "age",
+            "type": "u32"
+          },
+          {
+            "name": "_padding_0",
+            "type": {
+              "array": ["u8", 4]
+            }
+          },
+          {
+            "name": "bin_id",
+            "type": "i32"
+          },
+          {
+            "name": "is_ask",
+            "type": "u8"
+          },
+          {
+            "name": "_padding_1",
+            "type": {
+              "array": ["u8", 11]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityOneSideParameter",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "docs": ["Amount of X token or Y token to deposit"],
+            "type": "u64"
+          },
+          {
+            "name": "active_id",
+            "docs": ["Active bin that integrator observe off-chain"],
+            "type": "i32"
+          },
+          {
+            "name": "max_active_bin_slippage",
+            "docs": ["max active bin slippage allowed"],
+            "type": "i32"
+          },
+          {
+            "name": "bin_liquidity_dist",
+            "docs": ["Liquidity distribution to each bins"],
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "BinLiquidityDistributionByWeight"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityParameter",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_x",
+            "docs": ["Amount of X token to deposit"],
+            "type": "u64"
+          },
+          {
+            "name": "amount_y",
+            "docs": ["Amount of Y token to deposit"],
+            "type": "u64"
+          },
+          {
+            "name": "bin_liquidity_dist",
+            "docs": ["Liquidity distribution to each bins"],
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "BinLiquidityDistribution"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityParameterByStrategy",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_x",
+            "docs": ["Amount of X token to deposit"],
+            "type": "u64"
+          },
+          {
+            "name": "amount_y",
+            "docs": ["Amount of Y token to deposit"],
+            "type": "u64"
+          },
+          {
+            "name": "active_id",
+            "docs": ["Active bin that integrator observe off-chain"],
+            "type": "i32"
+          },
+          {
+            "name": "max_active_bin_slippage",
+            "docs": ["max active bin slippage allowed"],
+            "type": "i32"
+          },
+          {
+            "name": "strategy_parameters",
+            "docs": ["strategy parameters"],
+            "type": {
+              "defined": {
+                "name": "StrategyParameters"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityParameterByStrategyOneSide",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "docs": ["Amount of X token or Y token to deposit"],
+            "type": "u64"
+          },
+          {
+            "name": "active_id",
+            "docs": ["Active bin that integrator observe off-chain"],
+            "type": "i32"
+          },
+          {
+            "name": "max_active_bin_slippage",
+            "docs": ["max active bin slippage allowed"],
+            "type": "i32"
+          },
+          {
+            "name": "strategy_parameters",
+            "docs": ["strategy parameters"],
+            "type": {
+              "defined": {
+                "name": "StrategyParameters"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityParameterByWeight",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_x",
+            "docs": ["Amount of X token to deposit"],
+            "type": "u64"
+          },
+          {
+            "name": "amount_y",
+            "docs": ["Amount of Y token to deposit"],
+            "type": "u64"
+          },
+          {
+            "name": "active_id",
+            "docs": ["Active bin that integrator observe off-chain"],
+            "type": "i32"
+          },
+          {
+            "name": "max_active_bin_slippage",
+            "docs": ["max active bin slippage allowed"],
+            "type": "i32"
+          },
+          {
+            "name": "bin_liquidity_dist",
+            "docs": ["Liquidity distribution to each bins"],
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "BinLiquidityDistributionByWeight"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Operator",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "signer",
+            "type": "pubkey"
+          },
+          {
+            "name": "permission",
+            "type": "u128"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": ["u64", 2]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Oracle",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "idx",
+            "docs": ["Index of latest observation"],
+            "type": "u64"
+          },
+          {
+            "name": "active_size",
+            "docs": [
+              "Size of active sample. Active sample is initialized observation."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "length",
+            "docs": ["Number of observations"],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PairStatus",
+      "docs": [
+        "Pair status. 0 = Enabled, 1 = Disabled. Putting 0 as enabled for backward compatibility."
+      ],
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Enabled"
+          },
+          {
+            "name": "Disabled"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PairType",
+      "docs": [
+        "Type of the Pair. 0 = Permissionless, 1 = Permission, 2 = CustomizablePermissionless. Putting 0 as permissionless for backward compatibility."
+      ],
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Permissionless"
+          },
+          {
+            "name": "Permission"
+          },
+          {
+            "name": "CustomizablePermissionless"
+          },
+          {
+            "name": "PermissionlessV2"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PlaceLimitOrderEvt",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "sender",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "limit_order",
+            "type": "pubkey"
+          },
+          {
+            "name": "active_id",
+            "type": "i32"
+          },
+          {
+            "name": "params",
+            "type": {
+              "defined": {
+                "name": "PlaceLimitOrderParams"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PlaceLimitOrderParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "is_ask_side",
+            "type": "bool"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": ["u8", 16]
+            }
+          },
+          {
+            "name": "relative_bin",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "RelativeBin"
+                }
+              }
+            }
+          },
+          {
+            "name": "bins",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "BinLimitOrderAmount"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PositionBinData",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "liquidity_share",
+            "type": "u128"
+          },
+          {
+            "name": "reward_info",
+            "type": {
+              "defined": {
+                "name": "UserRewardInfo"
+              }
+            }
+          },
+          {
+            "name": "fee_info",
+            "type": {
+              "defined": {
+                "name": "FeeInfo"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PositionClose",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PositionCreate",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PositionV2",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "docs": ["The LB pair of this position"],
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "docs": [
+              "Owner of the position. Client rely on this to to fetch their positions."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "liquidity_shares",
+            "docs": [
+              "Liquidity shares of this position in bins (lower_bin_id <-> upper_bin_id). This is the same as LP concept."
+            ],
+            "type": {
+              "array": ["u128", 70]
+            }
+          },
+          {
+            "name": "reward_infos",
+            "docs": ["Farming reward information"],
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "UserRewardInfo"
+                  }
+                },
+                70
+              ]
+            }
+          },
+          {
+            "name": "fee_infos",
+            "docs": ["Swap fee to claim information"],
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "FeeInfo"
+                  }
+                },
+                70
+              ]
+            }
+          },
+          {
+            "name": "lower_bin_id",
+            "docs": ["Lower bin ID"],
+            "type": "i32"
+          },
+          {
+            "name": "upper_bin_id",
+            "docs": ["Upper bin ID"],
+            "type": "i32"
+          },
+          {
+            "name": "last_updated_at",
+            "docs": ["Last updated timestamp"],
+            "type": "i64"
+          },
+          {
+            "name": "total_claimed_fee_x_amount",
+            "docs": ["Total claimed token fee X"],
+            "type": "u64"
+          },
+          {
+            "name": "total_claimed_fee_y_amount",
+            "docs": ["Total claimed token fee Y"],
+            "type": "u64"
+          },
+          {
+            "name": "total_claimed_rewards",
+            "docs": ["Total claimed rewards"],
+            "type": {
+              "array": ["u64", 2]
+            }
+          },
+          {
+            "name": "operator",
+            "docs": ["Operator of position"],
+            "type": "pubkey"
+          },
+          {
+            "name": "lock_release_point",
+            "docs": ["Time point which the locked liquidity can be withdraw"],
+            "type": "u64"
+          },
+          {
+            "name": "_padding_0",
+            "docs": [
+              "_padding_0, previous subjected_to_bootstrap_liquidity_locking, BE CAREFUL FOR TOMBSTONE WHEN REUSE !!"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "fee_owner",
+            "docs": [
+              "Address is able to claim fee in this position, only valid for bootstrap_liquidity_position"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "version",
+            "docs": ["version to know whether we have reset tombstone fields"],
+            "type": "u8"
+          },
+          {
+            "name": "permissionless_operation_bits",
+            "type": "u8"
+          },
+          {
+            "name": "_reserved",
+            "docs": ["Reserved space for future use"],
+            "type": {
+              "array": ["u8", 85]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PresetParameter",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bin_step",
+            "docs": ["Bin step. Represent the price increment / decrement."],
+            "type": "u16"
+          },
+          {
+            "name": "base_factor",
+            "docs": [
+              "Used for base fee calculation. base_fee_rate = base_factor * bin_step * 10 * 10^base_fee_power_factor"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "filter_period",
+            "docs": [
+              "Filter period determine high frequency trading time window."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "docs": [
+              "Decay period determine when the volatile fee start decay / decrease."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "docs": [
+              "Reduction factor controls the volatile fee rate decrement rate."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "variable_fee_control",
+            "docs": [
+              "Used to scale the variable fee component depending on the dynamic of the market"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "docs": [
+              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "min_bin_id",
+            "docs": [
+              "Min bin id supported by the pool based on the configured bin step."
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "max_bin_id",
+            "docs": [
+              "Max bin id supported by the pool based on the configured bin step."
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "protocol_share",
+            "docs": [
+              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
+            ],
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PresetParameter2",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bin_step",
+            "docs": ["Bin step. Represent the price increment / decrement."],
+            "type": "u16"
+          },
+          {
+            "name": "base_factor",
+            "docs": [
+              "Used for base fee calculation. base_fee_rate = base_factor * bin_step * 10 * 10^base_fee_power_factor"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "filter_period",
+            "docs": [
+              "Filter period determine high frequency trading time window."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "docs": [
+              "Decay period determine when the volatile fee start decay / decrease."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "variable_fee_control",
+            "docs": [
+              "Used to scale the variable fee component depending on the dynamic of the market"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "docs": [
+              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "reduction_factor",
+            "docs": [
+              "Reduction factor controls the volatile fee rate decrement rate."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "protocol_share",
+            "docs": [
+              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "index",
+            "docs": ["index"],
+            "type": "u16"
+          },
+          {
+            "name": "base_fee_power_factor",
+            "docs": ["Base fee power factor"],
+            "type": "u8"
+          },
+          {
+            "name": "concrete_function_type",
+            "docs": [
+              "function type, to check whether the pool should have LM farming or other functions in the future, refer ConcreteFunctionType"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "collect_fee_mode",
+            "docs": ["collect fee mode"],
+            "type": "u8"
+          },
+          {
+            "name": "padding_0",
+            "type": {
+              "array": ["u8", 7]
+            }
+          },
+          {
+            "name": "padding_1",
+            "docs": ["Padding 1 for future use"],
+            "type": {
+              "array": ["u64", 19]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProtocolFee",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_x",
+            "type": "u64"
+          },
+          {
+            "name": "amount_y",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RebalanceLiquidityParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "active_id",
+            "docs": ["active id"],
+            "type": "i32"
+          },
+          {
+            "name": "max_active_bin_slippage",
+            "docs": ["max active bin slippage allowed"],
+            "type": "u16"
+          },
+          {
+            "name": "should_claim_fee",
+            "docs": ["a flag to indicate that whether fee should be harvested"],
+            "type": "bool"
+          },
+          {
+            "name": "should_claim_reward",
+            "docs": [
+              "a flag to indicate that whether rewards should be harvested"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "min_withdraw_x_amount",
+            "docs": ["threshold for withdraw token x"],
+            "type": "u64"
+          },
+          {
+            "name": "max_deposit_x_amount",
+            "docs": ["threshold for deposit token x"],
+            "type": "u64"
+          },
+          {
+            "name": "min_withdraw_y_amount",
+            "docs": ["threshold for withdraw token y"],
+            "type": "u64"
+          },
+          {
+            "name": "max_deposit_y_amount",
+            "docs": ["threshold for deposit token y"],
+            "type": "u64"
+          },
+          {
+            "name": "shrink_mode",
+            "docs": ["shrink mode"],
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "docs": ["padding 32 bytes for future usage"],
+            "type": {
+              "array": ["u8", 31]
+            }
+          },
+          {
+            "name": "removes",
+            "docs": ["removes"],
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "RemoveLiquidityParams"
+                }
+              }
+            }
+          },
+          {
+            "name": "adds",
+            "docs": ["adds"],
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "AddLiquidityParams"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Rebalancing",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "active_bin_id",
+            "type": "i32"
+          },
+          {
+            "name": "x_withdrawn_amount",
+            "type": "u64"
+          },
+          {
+            "name": "x_added_amount",
+            "type": "u64"
+          },
+          {
+            "name": "y_withdrawn_amount",
+            "type": "u64"
+          },
+          {
+            "name": "y_added_amount",
+            "type": "u64"
+          },
+          {
+            "name": "x_fee_amount",
+            "type": "u64"
+          },
+          {
+            "name": "y_fee_amount",
+            "type": "u64"
+          },
+          {
+            "name": "old_min_id",
+            "type": "i32"
+          },
+          {
+            "name": "old_max_id",
+            "type": "i32"
+          },
+          {
+            "name": "new_min_id",
+            "type": "i32"
+          },
+          {
+            "name": "new_max_id",
+            "type": "i32"
+          },
+          {
+            "name": "rewards",
+            "type": {
+              "array": ["u64", 2]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "RelativeBin",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "active_id",
+            "docs": ["Active bin that integrator observe off-chain"],
+            "type": "i32"
+          },
+          {
+            "name": "max_active_bin_slippage",
+            "docs": ["max active bin slippage allowed"],
+            "type": "i32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RemainingAccountsInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "slices",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "RemainingAccountsSlice"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "RemainingAccountsSlice",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "accounts_type",
+            "type": {
+              "defined": {
+                "name": "AccountsType"
+              }
+            }
+          },
+          {
+            "name": "length",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RemoveLiquidity",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "from",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "amounts",
+            "type": {
+              "array": ["u64", 2]
+            }
+          },
+          {
+            "name": "active_bin_id",
+            "type": "i32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RemoveLiquidityParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "min_bin_id",
+            "type": {
+              "option": "i32"
+            }
+          },
+          {
+            "name": "max_bin_id",
+            "type": {
+              "option": "i32"
+            }
+          },
+          {
+            "name": "bps",
+            "type": "u16"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": ["u8", 16]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ResizeSide",
+      "docs": ["Side of resize, 0 for lower and 1 for upper"],
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Lower"
+          },
+          {
+            "name": "Upper"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RewardInfo",
+      "docs": [
+        "Stores the state relevant for tracking liquidity mining rewards"
+      ],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mint",
+            "docs": ["Reward token mint."],
+            "type": "pubkey"
+          },
+          {
+            "name": "vault",
+            "docs": ["Reward vault token account."],
+            "type": "pubkey"
+          },
+          {
+            "name": "funder",
+            "docs": ["Authority account that allows to fund rewards"],
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_duration",
+            "docs": ["LM reward duration in seconds."],
+            "type": "u64"
+          },
+          {
+            "name": "reward_duration_end",
+            "docs": ["LM reward duration end time."],
+            "type": "u64"
+          },
+          {
+            "name": "reward_rate",
+            "docs": ["LM reward rate"],
+            "type": "u128"
+          },
+          {
+            "name": "last_update_time",
+            "docs": ["The last time reward states were updated."],
+            "type": "u64"
+          },
+          {
+            "name": "cumulative_seconds_with_empty_liquidity_reward",
+            "docs": [
+              "Accumulated seconds where when farm distribute rewards, but the bin is empty. The reward will be accumulated for next reward time window."
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Rounding",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Up"
+          },
+          {
+            "name": "Down"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SetPositionPermissionlessOperationBitsEvt",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "old_bits",
+            "type": "u8"
+          },
+          {
+            "name": "new_bits",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "StaticParameters",
+      "docs": ["Parameter that set by the protocol"],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "base_factor",
+            "docs": [
+              "Used for base fee calculation. base_fee_rate = base_factor * bin_step * 10 * 10^base_fee_power_factor"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "filter_period",
+            "docs": [
+              "Filter period determine high frequency trading time window."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "docs": [
+              "Decay period determine when the volatile fee start decay / decrease."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "docs": [
+              "Reduction factor controls the volatile fee rate decrement rate."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "variable_fee_control",
+            "docs": [
+              "Used to scale the variable fee component depending on the dynamic of the market"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "docs": [
+              "Maximum number of bin crossed can be accumulated. Used to cap volatile fee rate."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "min_bin_id",
+            "docs": [
+              "Min bin id supported by the pool based on the configured bin step."
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "max_bin_id",
+            "docs": [
+              "Max bin id supported by the pool based on the configured bin step."
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "protocol_share",
+            "docs": [
+              "Portion of swap fees retained by the protocol by controlling protocol_share parameter. protocol_swap_fee = protocol_share * total_swap_fee"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "base_fee_power_factor",
+            "docs": ["Base fee power factor"],
+            "type": "u8"
+          },
+          {
+            "name": "function_type",
+            "docs": ["function type"],
+            "type": "u8"
+          },
+          {
+            "name": "collect_fee_mode",
+            "docs": ["Collect fee mode"],
+            "type": "u8"
+          },
+          {
+            "name": "_padding",
+            "docs": ["Padding for bytemuck safe alignment"],
+            "type": {
+              "array": ["u8", 3]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "StrategyParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "min_bin_id",
+            "docs": ["min bin id"],
+            "type": "i32"
+          },
+          {
+            "name": "max_bin_id",
+            "docs": ["max bin id"],
+            "type": "i32"
+          },
+          {
+            "name": "strategy_type",
+            "docs": ["strategy type"],
+            "type": {
+              "defined": {
+                "name": "StrategyType"
+              }
+            }
+          },
+          {
+            "name": "parameteres",
+            "docs": ["parameters"],
+            "type": {
+              "array": ["u8", 64]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "StrategyType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "SpotOneSide"
+          },
+          {
+            "name": "CurveOneSide"
+          },
+          {
+            "name": "BidAskOneSide"
+          },
+          {
+            "name": "SpotBalanced"
+          },
+          {
+            "name": "CurveBalanced"
+          },
+          {
+            "name": "BidAskBalanced"
+          },
+          {
+            "name": "SpotImBalanced"
+          },
+          {
+            "name": "CurveImBalanced"
+          },
+          {
+            "name": "BidAskImBalanced"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Swap",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "from",
+            "type": "pubkey"
+          },
+          {
+            "name": "start_bin_id",
+            "type": "i32"
+          },
+          {
+            "name": "end_bin_id",
+            "type": "i32"
+          },
+          {
+            "name": "amount_in",
+            "type": "u64"
+          },
+          {
+            "name": "amount_out",
+            "type": "u64"
+          },
+          {
+            "name": "swap_for_y",
+            "type": "bool"
+          },
+          {
+            "name": "fee",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fee",
+            "type": "u64"
+          },
+          {
+            "name": "fee_bps",
+            "type": "u128"
+          },
+          {
+            "name": "host_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Swap2Evt",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "from",
+            "type": "pubkey"
+          },
+          {
+            "name": "start_bin_id",
+            "type": "i32"
+          },
+          {
+            "name": "end_bin_id",
+            "type": "i32"
+          },
+          {
+            "name": "swap_for_y",
+            "type": "bool"
+          },
+          {
+            "name": "fee_bps",
+            "type": "u128"
+          },
+          {
+            "name": "amount_in",
+            "docs": ["Total amount, user transfer out"],
+            "type": "u64"
+          },
+          {
+            "name": "amount_left",
+            "docs": ["Leftover amount"],
+            "type": "u64"
+          },
+          {
+            "name": "amount_out",
+            "docs": ["Total amount transfer to user, including transfer fee"],
+            "type": "u64"
+          },
+          {
+            "name": "mm_fee",
+            "docs": ["Market maker fee"],
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fee",
+            "docs": ["Total protocol fee"],
+            "type": "u64"
+          },
+          {
+            "name": "limit_order_fee",
+            "docs": ["Total limit order fee"],
+            "type": "u64"
+          },
+          {
+            "name": "host_fee",
+            "docs": ["Total host fee"],
+            "type": "u64"
+          },
+          {
+            "name": "fees_on_input",
+            "docs": ["check if fees on input"],
+            "type": "bool"
+          },
+          {
+            "name": "fees_on_token_x",
+            "docs": ["check if fees is on token x"],
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenBadge",
+      "docs": ["Parameter that set by the protocol"],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "token_mint",
+            "docs": ["token mint"],
+            "type": "pubkey"
+          },
+          {
+            "name": "_padding",
+            "docs": ["Reserve"],
+            "type": {
+              "array": ["u8", 128]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenProgramFlags",
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "TokenProgram"
+          },
+          {
+            "name": "TokenProgram2022"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdatePositionLockReleasePoint",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "current_point",
+            "type": "u64"
+          },
+          {
+            "name": "new_lock_release_point",
+            "type": "u64"
+          },
+          {
+            "name": "old_lock_release_point",
+            "type": "u64"
+          },
+          {
+            "name": "sender",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdatePositionOperator",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "old_operator",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_operator",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateRewardDuration",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_index",
+            "type": "u64"
+          },
+          {
+            "name": "old_reward_duration",
+            "type": "u64"
+          },
+          {
+            "name": "new_reward_duration",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateRewardFunder",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_index",
+            "type": "u64"
+          },
+          {
+            "name": "old_funder",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_funder",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "UserRewardInfo",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "reward_per_token_completes",
+            "type": {
+              "array": ["u128", 2]
+            }
+          },
+          {
+            "name": "reward_pendings",
+            "type": {
+              "array": ["u64", 2]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "VariableParameters",
+      "docs": ["Parameters that changes based on dynamic of the market"],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "volatility_accumulator",
+            "docs": [
+              "Volatility accumulator measure the number of bin crossed since reference bin ID. Normally (without filter period taken into consideration), reference bin ID is the active bin of last swap.",
+              "It affects the variable fee rate"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "volatility_reference",
+            "docs": [
+              "Volatility reference is decayed volatility accumulator. It is always <= volatility_accumulator"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "index_reference",
+            "docs": ["Active bin id of last swap."],
+            "type": "i32"
+          },
+          {
+            "name": "_padding",
+            "docs": ["Padding for bytemuck safe alignment"],
+            "type": {
+              "array": ["u8", 4]
+            }
+          },
+          {
+            "name": "last_update_timestamp",
+            "docs": ["Last timestamp the variable parameters was updated"],
+            "type": "i64"
+          },
+          {
+            "name": "_padding_1",
+            "docs": ["Padding for bytemuck safe alignment"],
+            "type": {
+              "array": ["u8", 8]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawIneligibleReward",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lb_pair",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    }
+  ],
+  "constants": [
+    {
+      "name": "BASIS_POINT_MAX",
+      "type": "u16",
+      "value": "10000"
+    },
+    {
+      "name": "BIN_ARRAY",
+      "type": "bytes",
+      "value": "[98, 105, 110, 95, 97, 114, 114, 97, 121]"
+    },
+    {
+      "name": "BIN_ARRAY_BITMAP_SEED",
+      "type": "bytes",
+      "value": "[98, 105, 116, 109, 97, 112]"
+    },
+    {
+      "name": "BIN_ARRAY_BITMAP_SIZE",
+      "type": "i32",
+      "value": "512"
+    },
+    {
+      "name": "CLAIM_PROTOCOL_FEE_OPERATOR",
+      "type": "bytes",
+      "value": "[99, 102, 95, 111, 112, 101, 114, 97, 116, 111, 114]"
+    },
+    {
+      "name": "DEFAULT_BIN_PER_POSITION",
+      "type": "u64",
+      "value": "70"
+    },
+    {
+      "name": "EXTENSION_BINARRAY_BITMAP_SIZE",
+      "type": "u64",
+      "value": "12"
+    },
+    {
+      "name": "FEE_DENOMINATOR",
+      "type": "u64",
+      "value": "1000000000"
+    },
+    {
+      "name": "HOST_FEE_BPS",
+      "docs": ["Host fee. 20%"],
+      "type": "u16",
+      "value": "2000"
+    },
+    {
+      "name": "ILM_PROTOCOL_SHARE",
+      "type": "u16",
+      "value": "2000"
+    },
+    {
+      "name": "LIMIT_ORDER_FEE_SHARE",
+      "type": "u16",
+      "value": "5000"
+    },
+    {
+      "name": "MAX_BASE_FEE",
+      "docs": ["Maximum base fee, base_fee / 10^9 = fee_in_percentage"],
+      "type": "u128",
+      "value": "100000000"
+    },
+    {
+      "name": "MAX_BIN_ID_PER_BIN_STEP",
+      "docs": [
+        "Maximum bin ID per bin step. Computed based on 1 bps. Used for bin id bound estimation."
+      ],
+      "type": "i32",
+      "value": "351639"
+    },
+    {
+      "name": "MAX_BIN_PER_ARRAY",
+      "type": "u64",
+      "value": "70"
+    },
+    {
+      "name": "MAX_BIN_PER_LIMIT_ORDER",
+      "type": "u64",
+      "value": "50"
+    },
+    {
+      "name": "MAX_BIN_STEP",
+      "docs": ["Maximum bin step"],
+      "type": "u16",
+      "value": "400"
+    },
+    {
+      "name": "MAX_FEE_RATE",
+      "docs": ["Maximum fee rate. 10%"],
+      "type": "u64",
+      "value": "100000000"
+    },
+    {
+      "name": "MAX_PROTOCOL_SHARE",
+      "docs": ["Maximum protocol share of the fee. 25%"],
+      "type": "u16",
+      "value": "2500"
+    },
+    {
+      "name": "MAX_RESIZE_LENGTH",
+      "type": "u64",
+      "value": "91"
+    },
+    {
+      "name": "MAX_REWARD_BIN_SPLIT",
+      "type": "u64",
+      "value": "15"
+    },
+    {
+      "name": "MAX_REWARD_DURATION",
+      "type": "u64",
+      "value": "31536000"
+    },
+    {
+      "name": "MINIMUM_LIQUIDITY",
+      "type": "u128",
+      "value": "1000000"
+    },
+    {
+      "name": "MIN_BASE_FEE",
+      "docs": ["Minimum base fee"],
+      "type": "u128",
+      "value": "100000"
+    },
+    {
+      "name": "MIN_REWARD_DURATION",
+      "type": "u64",
+      "value": "1"
+    },
+    {
+      "name": "NUM_REWARDS",
+      "type": "u64",
+      "value": "2"
+    },
+    {
+      "name": "OPERATOR_PREFIX",
+      "type": "bytes",
+      "value": "[111, 112, 101, 114, 97, 116, 111, 114]"
+    },
+    {
+      "name": "ORACLE",
+      "type": "bytes",
+      "value": "[111, 114, 97, 99, 108, 101]"
+    },
+    {
+      "name": "POSITION",
+      "type": "bytes",
+      "value": "[112, 111, 115, 105, 116, 105, 111, 110]"
+    },
+    {
+      "name": "POSITION_MAX_LENGTH",
+      "type": "u64",
+      "value": "1400"
+    },
+    {
+      "name": "PRESET_PARAMETER",
+      "type": "bytes",
+      "value": "[112, 114, 101, 115, 101, 116, 95, 112, 97, 114, 97, 109, 101, 116, 101, 114]"
+    },
+    {
+      "name": "PRESET_PARAMETER2",
+      "type": "bytes",
+      "value": "[112, 114, 101, 115, 101, 116, 95, 112, 97, 114, 97, 109, 101, 116, 101, 114, 50]"
+    },
+    {
+      "name": "PROTOCOL_SHARE",
+      "type": "u16",
+      "value": "500"
     }
   ]
 }

--- a/idl/meteora_dynamic_bonding_curve.json
+++ b/idl/meteora_dynamic_bonding_curve.json
@@ -1,0 +1,6964 @@
+{
+  "address": "dbcij3LWUppWqq96dh6gJWwBifmcGfLSB5D4DuSMaqN",
+  "metadata": {
+    "name": "dynamic_bonding_curve",
+    "version": "0.2.0",
+    "spec": "0.1.0",
+    "description": "Created with Anchor"
+  },
+  "instructions": [
+    {
+      "name": "claim_creator_trading_fee",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        82,
+        220,
+        250,
+        189,
+        3,
+        85,
+        107,
+        45
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "token_a_account",
+          "docs": [
+            "The treasury token a account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_b_account",
+          "docs": [
+            "The treasury token b account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of token a"
+          ]
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of token b"
+          ]
+        },
+        {
+          "name": "creator",
+          "signer": true
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_base_amount",
+          "type": "u64"
+        },
+        {
+          "name": "max_quote_amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "claim_creator_trading_fee2",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        238,
+        247,
+        213,
+        94,
+        110,
+        145,
+        88,
+        142
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "token_a_account",
+          "docs": [
+            "The treasury token a account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_b_account",
+          "docs": [
+            "The treasury token b account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of token a"
+          ]
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of token b"
+          ]
+        },
+        {
+          "name": "creator",
+          "signer": true
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_base_amount",
+          "type": "u64"
+        },
+        {
+          "name": "max_quote_amount",
+          "type": "u64"
+        },
+        {
+          "name": "transfer_hook_accounts_info",
+          "type": {
+            "defined": {
+              "name": "TransferHookAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "claim_partner_pool_creation_fee",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        250,
+        238,
+        26,
+        4,
+        139,
+        10,
+        101,
+        248
+      ],
+      "accounts": [
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "fee_claimer",
+          "signer": true
+        },
+        {
+          "name": "fee_receiver",
+          "writable": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "claim_protocol_fee",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        165,
+        228,
+        133,
+        48,
+        99,
+        249,
+        255,
+        33
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config",
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for input token"
+          ],
+          "writable": true,
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true,
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of token a"
+          ],
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of token b"
+          ],
+          "relations": [
+            "config"
+          ]
+        },
+        {
+          "name": "token_base_account",
+          "writable": true
+        },
+        {
+          "name": "token_quote_account",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Signer"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_base_amount",
+          "type": "u64"
+        },
+        {
+          "name": "max_quote_amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "claim_protocol_fee2",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        235,
+        194,
+        54,
+        69,
+        65,
+        10,
+        236,
+        112
+      ],
+      "accounts": [
+        {
+          "name": "receiver_token_account",
+          "docs": [
+            "receiver token account for the claimed token. validated through the protocol_fee program"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint"
+        },
+        {
+          "name": "quote_mint"
+        },
+        {
+          "name": "token_base_program"
+        },
+        {
+          "name": "token_quote_program"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "writable": true
+        },
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "signer",
+          "signer": true,
+          "address": "FkU5rQCWQM131skHCpcEbK8P1JrQGsBgqXe55w525SSF"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "claim_protocol_pool_creation_fee",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        114,
+        205,
+        83,
+        188,
+        240,
+        153,
+        25,
+        54
+      ],
+      "accounts": [
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Operator"
+          ],
+          "signer": true
+        },
+        {
+          "name": "treasury",
+          "writable": true,
+          "address": "6aYhxiNGmG8AyU25rh2R7iFu4pBrqnQHpNUGhmsEXRcm"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "claim_trading_fee",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        8,
+        236,
+        89,
+        49,
+        152,
+        125,
+        177,
+        81
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "token_a_account",
+          "docs": [
+            "The treasury token a account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_b_account",
+          "docs": [
+            "The treasury token b account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of token a"
+          ]
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of token b"
+          ]
+        },
+        {
+          "name": "fee_claimer",
+          "signer": true
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount_a",
+          "type": "u64"
+        },
+        {
+          "name": "max_amount_b",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "claim_trading_fee2",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        84,
+        191,
+        71,
+        50,
+        9,
+        162,
+        55,
+        193
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "token_a_account",
+          "docs": [
+            "The treasury token a account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_b_account",
+          "docs": [
+            "The treasury token b account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of token a"
+          ]
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of token b"
+          ]
+        },
+        {
+          "name": "fee_claimer",
+          "signer": true
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount_a",
+          "type": "u64"
+        },
+        {
+          "name": "max_amount_b",
+          "type": "u64"
+        },
+        {
+          "name": "transfer_hook_accounts_info",
+          "type": {
+            "defined": {
+              "name": "TransferHookAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "close_claim_protocol_fee_operator",
+      "discriminator": [
+        8,
+        41,
+        87,
+        35,
+        80,
+        48,
+        121,
+        26
+      ],
+      "accounts": [
+        {
+          "name": "claim_fee_operator",
+          "writable": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_operator_account",
+      "discriminator": [
+        171,
+        9,
+        213,
+        74,
+        120,
+        23,
+        3,
+        29
+      ],
+      "accounts": [
+        {
+          "name": "operator",
+          "writable": true
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "create_config",
+      "discriminator": [
+        201,
+        207,
+        243,
+        114,
+        75,
+        111,
+        47,
+        189
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "fee_claimer"
+        },
+        {
+          "name": "leftover_receiver"
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "quote mint"
+          ]
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "config_parameters",
+          "type": {
+            "defined": {
+              "name": "ConfigParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "create_config_with_transfer_hook",
+      "discriminator": [
+        216,
+        37,
+        1,
+        57,
+        88,
+        226,
+        25,
+        41
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "fee_claimer"
+        },
+        {
+          "name": "leftover_receiver"
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "quote mint"
+          ]
+        },
+        {
+          "name": "transfer_hook_program"
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "config_parameters",
+          "type": {
+            "defined": {
+              "name": "ConfigParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "create_locker",
+      "docs": [
+        "PERMISSIONLESS FUNCTIONS ///",
+        "create locker",
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        167,
+        90,
+        137,
+        154,
+        75,
+        47,
+        17,
+        84
+      ],
+      "accounts": [
+        {
+          "name": "virtual_pool",
+          "writable": true
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool_authority",
+          "writable": true,
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "base_vault",
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "writable": true
+        },
+        {
+          "name": "base",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  98,
+                  97,
+                  115,
+                  101,
+                  95,
+                  108,
+                  111,
+                  99,
+                  107,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "virtual_pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "creator"
+        },
+        {
+          "name": "escrow",
+          "writable": true
+        },
+        {
+          "name": "escrow_token",
+          "writable": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "locker_program",
+          "address": "LocpQgucEQHbqNABEYvBvwoxCPsSbG91A1QaQhQQqjn"
+        },
+        {
+          "name": "locker_event_authority"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ],
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "create_operator_account",
+      "discriminator": [
+        221,
+        64,
+        246,
+        149,
+        240,
+        153,
+        229,
+        163
+      ],
+      "accounts": [
+        {
+          "name": "operator",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  112,
+                  101,
+                  114,
+                  97,
+                  116,
+                  111,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "whitelisted_address"
+              }
+            ]
+          }
+        },
+        {
+          "name": "whitelisted_address"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "permission",
+          "type": "u128"
+        }
+      ]
+    },
+    {
+      "name": "create_partner_metadata",
+      "docs": [
+        "PARTNER FUNCTIONS ///"
+      ],
+      "discriminator": [
+        192,
+        168,
+        234,
+        191,
+        188,
+        226,
+        227,
+        255
+      ],
+      "accounts": [
+        {
+          "name": "partner_metadata",
+          "docs": [
+            "Partner metadata"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  97,
+                  114,
+                  116,
+                  110,
+                  101,
+                  114,
+                  95,
+                  109,
+                  101,
+                  116,
+                  97,
+                  100,
+                  97,
+                  116,
+                  97
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "fee_claimer"
+              }
+            ]
+          }
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "Payer of the partner metadata."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "fee_claimer",
+          "docs": [
+            "Fee claimer for partner"
+          ],
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ],
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "metadata",
+          "type": {
+            "defined": {
+              "name": "CreatePartnerMetadataParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "create_virtual_pool_metadata",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        45,
+        97,
+        187,
+        103,
+        254,
+        109,
+        124,
+        134
+      ],
+      "accounts": [
+        {
+          "name": "virtual_pool"
+        },
+        {
+          "name": "virtual_pool_metadata",
+          "docs": [
+            "Virtual pool metadata"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  105,
+                  114,
+                  116,
+                  117,
+                  97,
+                  108,
+                  95,
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  109,
+                  101,
+                  116,
+                  97,
+                  100,
+                  97,
+                  116,
+                  97
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "virtual_pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "creator",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "Payer of the virtual pool metadata."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ],
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "metadata",
+          "type": {
+            "defined": {
+              "name": "CreateVirtualPoolMetadataParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "creator_withdraw_surplus",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        165,
+        3,
+        137,
+        7,
+        28,
+        134,
+        76,
+        80
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "virtual_pool",
+          "writable": true
+        },
+        {
+          "name": "token_quote_account",
+          "docs": [
+            "The receiver token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of quote token"
+          ]
+        },
+        {
+          "name": "creator",
+          "signer": true
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initialize_virtual_pool_with_spl_token",
+      "docs": [
+        "POOL CREATOR FUNCTIONS ////",
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        140,
+        85,
+        215,
+        176,
+        102,
+        54,
+        104,
+        79
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "docs": [
+            "Which config the pool belongs to."
+          ]
+        },
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "creator",
+          "signer": true
+        },
+        {
+          "name": "base_mint",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "quote_mint",
+          "relations": [
+            "config"
+          ]
+        },
+        {
+          "name": "pool",
+          "docs": [
+            "Initialize an account to store the pool state"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "Token a vault for the pool"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "base_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "Token b vault for the pool"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "quote_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "mint_metadata",
+          "writable": true
+        },
+        {
+          "name": "metadata_program",
+          "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "Address paying to create the pool. Can be anyone"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ]
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "InitializePoolParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "initialize_virtual_pool_with_token2022",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        169,
+        118,
+        51,
+        78,
+        145,
+        110,
+        220,
+        155
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "docs": [
+            "Which config the pool belongs to."
+          ]
+        },
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "creator",
+          "signer": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "Unique token mint address, initialize in contract"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "quote_mint",
+          "relations": [
+            "config"
+          ]
+        },
+        {
+          "name": "pool",
+          "docs": [
+            "Initialize an account to store the pool state"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "base_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "Token quote vault for the pool"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "quote_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "Address paying to create the pool. Can be anyone"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ]
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "token program for base mint"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "InitializePoolParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "initialize_virtual_pool_with_token2022_transfer_hook",
+      "docs": [
+        "Accepts: TransferHookPool only."
+      ],
+      "discriminator": [
+        182,
+        13,
+        233,
+        177,
+        42,
+        145,
+        135,
+        2
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "docs": [
+            "Transfer hook config — contains the transfer hook program set by partner"
+          ]
+        },
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "creator",
+          "signer": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "Unique token mint address, initialize in contract"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "quote_mint",
+          "relations": [
+            "config"
+          ]
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "base_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "quote_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "quote_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "transfer_hook_program"
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_quote_program"
+        },
+        {
+          "name": "token_program",
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "InitializePoolParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "migrate_meteora_damm",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        27,
+        1,
+        48,
+        22,
+        180,
+        63,
+        118,
+        217
+      ],
+      "accounts": [
+        {
+          "name": "virtual_pool",
+          "docs": [
+            "virtual pool"
+          ],
+          "writable": true,
+          "relations": [
+            "migration_metadata"
+          ]
+        },
+        {
+          "name": "migration_metadata",
+          "writable": true
+        },
+        {
+          "name": "config",
+          "relations": [
+            "virtual_pool"
+          ]
+        },
+        {
+          "name": "pool_authority",
+          "writable": true,
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "damm_config",
+          "docs": [
+            "pool config"
+          ]
+        },
+        {
+          "name": "lp_mint",
+          "writable": true
+        },
+        {
+          "name": "token_a_mint",
+          "writable": true
+        },
+        {
+          "name": "token_b_mint"
+        },
+        {
+          "name": "a_vault",
+          "writable": true
+        },
+        {
+          "name": "b_vault",
+          "writable": true
+        },
+        {
+          "name": "a_token_vault",
+          "writable": true
+        },
+        {
+          "name": "b_token_vault",
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp_mint",
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp_mint",
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp",
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp",
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "writable": true,
+          "relations": [
+            "virtual_pool"
+          ]
+        },
+        {
+          "name": "quote_vault",
+          "writable": true,
+          "relations": [
+            "virtual_pool"
+          ]
+        },
+        {
+          "name": "virtual_pool_lp",
+          "writable": true
+        },
+        {
+          "name": "protocol_token_a_fee",
+          "writable": true
+        },
+        {
+          "name": "protocol_token_b_fee",
+          "writable": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "rent"
+        },
+        {
+          "name": "mint_metadata",
+          "writable": true
+        },
+        {
+          "name": "metadata_program"
+        },
+        {
+          "name": "amm_program",
+          "address": "Eo7WjKq67rjJQSZxS6z3YkapzY3eMj6Xy8X5EQVn5UaB"
+        },
+        {
+          "name": "vault_program"
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "token_program"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ],
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "migrate_meteora_damm_claim_lp_token",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        139,
+        133,
+        2,
+        30,
+        91,
+        145,
+        127,
+        154
+      ],
+      "accounts": [
+        {
+          "name": "virtual_pool",
+          "relations": [
+            "migration_metadata"
+          ]
+        },
+        {
+          "name": "migration_metadata",
+          "docs": [
+            "migration metadata"
+          ],
+          "writable": true
+        },
+        {
+          "name": "pool_authority",
+          "writable": true,
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "lp_mint",
+          "relations": [
+            "migration_metadata"
+          ]
+        },
+        {
+          "name": "source_token",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "pool_authority"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "migration_metadata"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "destination_token",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "owner"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "migration_metadata"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "owner"
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "token_program"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "migrate_meteora_damm_lock_lp_token",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        177,
+        55,
+        238,
+        157,
+        251,
+        88,
+        165,
+        42
+      ],
+      "accounts": [
+        {
+          "name": "virtual_pool",
+          "relations": [
+            "migration_metadata"
+          ]
+        },
+        {
+          "name": "migration_metadata",
+          "docs": [
+            "migration_metadata"
+          ],
+          "writable": true
+        },
+        {
+          "name": "pool_authority",
+          "writable": true,
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "pool",
+          "writable": true,
+          "relations": [
+            "lock_escrow"
+          ]
+        },
+        {
+          "name": "lp_mint",
+          "relations": [
+            "migration_metadata"
+          ]
+        },
+        {
+          "name": "lock_escrow",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "relations": [
+            "lock_escrow"
+          ]
+        },
+        {
+          "name": "source_tokens",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "pool_authority"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "migration_metadata"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "escrow_vault",
+          "writable": true
+        },
+        {
+          "name": "amm_program",
+          "address": "Eo7WjKq67rjJQSZxS6z3YkapzY3eMj6Xy8X5EQVn5UaB"
+        },
+        {
+          "name": "a_vault"
+        },
+        {
+          "name": "b_vault"
+        },
+        {
+          "name": "a_vault_lp"
+        },
+        {
+          "name": "b_vault_lp"
+        },
+        {
+          "name": "a_vault_lp_mint"
+        },
+        {
+          "name": "b_vault_lp_mint"
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "token_program"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "migration_damm_v2",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        156,
+        169,
+        230,
+        103,
+        53,
+        228,
+        80,
+        64
+      ],
+      "accounts": [
+        {
+          "name": "virtual_pool",
+          "writable": true
+        },
+        {
+          "name": "migration_metadata"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool_authority",
+          "writable": true,
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "first_position_nft_mint",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "first_position_nft_account",
+          "writable": true
+        },
+        {
+          "name": "first_position",
+          "writable": true
+        },
+        {
+          "name": "second_position_nft_mint",
+          "writable": true,
+          "signer": true,
+          "optional": true
+        },
+        {
+          "name": "second_position_nft_account",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "second_position",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "damm_pool_authority"
+        },
+        {
+          "name": "amm_program",
+          "address": "cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG"
+        },
+        {
+          "name": "base_mint",
+          "writable": true
+        },
+        {
+          "name": "quote_mint",
+          "writable": true
+        },
+        {
+          "name": "token_a_vault",
+          "writable": true
+        },
+        {
+          "name": "token_b_vault",
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "writable": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_base_program"
+        },
+        {
+          "name": "token_quote_program"
+        },
+        {
+          "name": "token_2022_program"
+        },
+        {
+          "name": "damm_event_authority"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ],
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "migration_damm_v2_create_metadata",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        109,
+        189,
+        19,
+        36,
+        195,
+        183,
+        222,
+        82
+      ],
+      "accounts": [
+        {
+          "name": "virtual_pool"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "migration_metadata"
+        },
+        {
+          "name": "payer"
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "migration_meteora_damm_create_metadata",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        47,
+        94,
+        126,
+        115,
+        221,
+        226,
+        194,
+        133
+      ],
+      "accounts": [
+        {
+          "name": "virtual_pool"
+        },
+        {
+          "name": "config",
+          "relations": [
+            "virtual_pool"
+          ]
+        },
+        {
+          "name": "migration_metadata",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  109,
+                  101,
+                  116,
+                  101,
+                  111,
+                  114,
+                  97
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "virtual_pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "partner_withdraw_surplus",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        168,
+        173,
+        72,
+        100,
+        201,
+        98,
+        38,
+        92
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "virtual_pool",
+          "writable": true
+        },
+        {
+          "name": "token_quote_account",
+          "docs": [
+            "The receiver token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of quote token"
+          ]
+        },
+        {
+          "name": "fee_claimer",
+          "signer": true
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "swap",
+      "docs": [
+        "TRADING BOTS FUNCTIONS ////",
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        248,
+        198,
+        158,
+        145,
+        225,
+        117,
+        135,
+        200
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "input_token_account",
+          "docs": [
+            "The user token account for input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "output_token_account",
+          "docs": [
+            "The user token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for base token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for quote token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of base token"
+          ]
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of quote token"
+          ]
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "The user performing the swap"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token base program"
+          ]
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token quote program"
+          ]
+        },
+        {
+          "name": "referral_token_account",
+          "docs": [
+            "referral token account"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "SwapParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "swap2",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        65,
+        75,
+        63,
+        76,
+        235,
+        91,
+        91,
+        136
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "input_token_account",
+          "docs": [
+            "The user token account for input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "output_token_account",
+          "docs": [
+            "The user token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for base token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for quote token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of base token"
+          ]
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of quote token"
+          ]
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "The user performing the swap"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token base program"
+          ]
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token quote program"
+          ]
+        },
+        {
+          "name": "referral_token_account",
+          "docs": [
+            "referral token account"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "SwapParameters2"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "swap2_with_transfer_hook",
+      "docs": [
+        "Accepts: TransferHookPool only."
+      ],
+      "discriminator": [
+        183,
+        93,
+        153,
+        40,
+        24,
+        230,
+        194,
+        151
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "input_token_account",
+          "docs": [
+            "The user token account for input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "output_token_account",
+          "docs": [
+            "The user token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for base token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for quote token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of base token",
+            "must be mutable so we can revoke the transfer hook after the last swap is performed"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of quote token"
+          ]
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "The user performing the swap"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token base program"
+          ]
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token quote program"
+          ]
+        },
+        {
+          "name": "referral_token_account",
+          "docs": [
+            "referral token account"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "SwapParameters2"
+            }
+          }
+        },
+        {
+          "name": "transfer_hook_accounts_info",
+          "type": {
+            "defined": {
+              "name": "TransferHookAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "transfer_pool_creator",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        20,
+        7,
+        169,
+        33,
+        58,
+        147,
+        166,
+        33
+      ],
+      "accounts": [
+        {
+          "name": "virtual_pool",
+          "writable": true
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "creator",
+          "signer": true
+        },
+        {
+          "name": "new_creator"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "withdraw_leftover",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        20,
+        198,
+        202,
+        237,
+        235,
+        243,
+        183,
+        66
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "virtual_pool",
+          "writable": true
+        },
+        {
+          "name": "token_base_account",
+          "docs": [
+            "The receiver token account, withdraw to ATA"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "leftover_receiver"
+              },
+              {
+                "kind": "account",
+                "path": "token_base_program"
+              },
+              {
+                "kind": "account",
+                "path": "base_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of quote token"
+          ]
+        },
+        {
+          "name": "leftover_receiver"
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token base program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "withdraw_migration_fee",
+      "docs": [
+        "BOTH partner and creator FUNCTIONS ///",
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        237,
+        142,
+        45,
+        23,
+        129,
+        6,
+        222,
+        162
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "virtual_pool",
+          "writable": true
+        },
+        {
+          "name": "token_quote_account",
+          "docs": [
+            "The receiver token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of quote token"
+          ]
+        },
+        {
+          "name": "sender",
+          "signer": true
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "flag",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "zap_protocol_fee",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        213,
+        155,
+        187,
+        34,
+        56,
+        182,
+        91,
+        240
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config",
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "token_vault",
+          "writable": true
+        },
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "receiver_token",
+          "writable": true
+        },
+        {
+          "name": "operator",
+          "docs": [
+            "zap claim fee operator"
+          ]
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Operator"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program"
+          ]
+        },
+        {
+          "name": "sysvar_instructions",
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount",
+          "type": "u64"
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "ClaimFeeOperator",
+      "discriminator": [
+        166,
+        48,
+        134,
+        86,
+        34,
+        200,
+        188,
+        150
+      ]
+    },
+    {
+      "name": "ConfigWithTransferHook",
+      "discriminator": [
+        40,
+        220,
+        194,
+        251,
+        41,
+        199,
+        123,
+        253
+      ]
+    },
+    {
+      "name": "MeteoraDammMigrationMetadata",
+      "discriminator": [
+        17,
+        155,
+        141,
+        215,
+        207,
+        4,
+        133,
+        156
+      ]
+    },
+    {
+      "name": "Operator",
+      "discriminator": [
+        219,
+        31,
+        188,
+        145,
+        69,
+        139,
+        204,
+        117
+      ]
+    },
+    {
+      "name": "PartnerMetadata",
+      "discriminator": [
+        68,
+        68,
+        130,
+        19,
+        16,
+        209,
+        98,
+        156
+      ]
+    },
+    {
+      "name": "PoolConfig",
+      "discriminator": [
+        26,
+        108,
+        14,
+        123,
+        116,
+        230,
+        129,
+        43
+      ]
+    },
+    {
+      "name": "TransferHookPool",
+      "discriminator": [
+        237,
+        219,
+        184,
+        23,
+        42,
+        189,
+        169,
+        35
+      ]
+    },
+    {
+      "name": "VirtualPool",
+      "discriminator": [
+        213,
+        224,
+        5,
+        209,
+        98,
+        69,
+        119,
+        92
+      ]
+    },
+    {
+      "name": "VirtualPoolMetadata",
+      "discriminator": [
+        217,
+        37,
+        82,
+        250,
+        43,
+        47,
+        228,
+        254
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "EvtClaimCreatorTradingFee",
+      "discriminator": [
+        154,
+        228,
+        215,
+        202,
+        133,
+        155,
+        214,
+        138
+      ]
+    },
+    {
+      "name": "EvtClaimPoolCreationFee",
+      "discriminator": [
+        149,
+        111,
+        149,
+        44,
+        136,
+        64,
+        175,
+        62
+      ]
+    },
+    {
+      "name": "EvtClaimProtocolFee",
+      "discriminator": [
+        186,
+        244,
+        75,
+        251,
+        188,
+        13,
+        25,
+        33
+      ]
+    },
+    {
+      "name": "EvtClaimProtocolFee2",
+      "discriminator": [
+        187,
+        133,
+        66,
+        9,
+        205,
+        161,
+        84,
+        13
+      ]
+    },
+    {
+      "name": "EvtClaimTradingFee",
+      "discriminator": [
+        26,
+        83,
+        117,
+        240,
+        92,
+        202,
+        112,
+        254
+      ]
+    },
+    {
+      "name": "EvtCloseClaimFeeOperator",
+      "discriminator": [
+        111,
+        39,
+        37,
+        55,
+        110,
+        216,
+        194,
+        23
+      ]
+    },
+    {
+      "name": "EvtCreateClaimFeeOperator",
+      "discriminator": [
+        21,
+        6,
+        153,
+        120,
+        68,
+        116,
+        28,
+        177
+      ]
+    },
+    {
+      "name": "EvtCreateConfig",
+      "discriminator": [
+        131,
+        207,
+        180,
+        174,
+        180,
+        73,
+        165,
+        54
+      ]
+    },
+    {
+      "name": "EvtCreateConfigV2",
+      "discriminator": [
+        163,
+        74,
+        66,
+        187,
+        119,
+        195,
+        26,
+        144
+      ]
+    },
+    {
+      "name": "EvtCreateConfigV2WithTransferHook",
+      "discriminator": [
+        182,
+        81,
+        135,
+        4,
+        39,
+        46,
+        132,
+        253
+      ]
+    },
+    {
+      "name": "EvtCreateMeteoraMigrationMetadata",
+      "discriminator": [
+        99,
+        167,
+        133,
+        63,
+        214,
+        143,
+        175,
+        139
+      ]
+    },
+    {
+      "name": "EvtCreatorWithdrawSurplus",
+      "discriminator": [
+        152,
+        73,
+        21,
+        15,
+        66,
+        87,
+        53,
+        157
+      ]
+    },
+    {
+      "name": "EvtCurveComplete",
+      "discriminator": [
+        229,
+        231,
+        86,
+        84,
+        156,
+        134,
+        75,
+        24
+      ]
+    },
+    {
+      "name": "EvtCurveCompleteWithTransferHook",
+      "discriminator": [
+        59,
+        47,
+        109,
+        205,
+        13,
+        31,
+        44,
+        159
+      ]
+    },
+    {
+      "name": "EvtInitializePool",
+      "discriminator": [
+        228,
+        50,
+        246,
+        85,
+        203,
+        66,
+        134,
+        37
+      ]
+    },
+    {
+      "name": "EvtInitializePoolWithTransferHook",
+      "discriminator": [
+        213,
+        137,
+        164,
+        53,
+        193,
+        74,
+        15,
+        110
+      ]
+    },
+    {
+      "name": "EvtPartnerClaimPoolCreationFee",
+      "discriminator": [
+        174,
+        223,
+        44,
+        150,
+        145,
+        98,
+        89,
+        195
+      ]
+    },
+    {
+      "name": "EvtPartnerMetadata",
+      "discriminator": [
+        200,
+        127,
+        6,
+        55,
+        13,
+        32,
+        8,
+        150
+      ]
+    },
+    {
+      "name": "EvtPartnerWithdrawSurplus",
+      "discriminator": [
+        195,
+        56,
+        152,
+        9,
+        232,
+        72,
+        35,
+        22
+      ]
+    },
+    {
+      "name": "EvtSwap",
+      "discriminator": [
+        27,
+        60,
+        21,
+        213,
+        138,
+        170,
+        187,
+        147
+      ]
+    },
+    {
+      "name": "EvtSwap2",
+      "discriminator": [
+        189,
+        66,
+        51,
+        168,
+        38,
+        80,
+        117,
+        153
+      ]
+    },
+    {
+      "name": "EvtSwap2WithTransferHook",
+      "discriminator": [
+        134,
+        59,
+        168,
+        120,
+        94,
+        51,
+        114,
+        231
+      ]
+    },
+    {
+      "name": "EvtUpdatePoolCreator",
+      "discriminator": [
+        107,
+        225,
+        165,
+        237,
+        91,
+        158,
+        213,
+        220
+      ]
+    },
+    {
+      "name": "EvtVirtualPoolMetadata",
+      "discriminator": [
+        188,
+        18,
+        72,
+        76,
+        195,
+        91,
+        38,
+        74
+      ]
+    },
+    {
+      "name": "EvtWithdrawLeftover",
+      "discriminator": [
+        191,
+        189,
+        104,
+        143,
+        111,
+        156,
+        94,
+        229
+      ]
+    },
+    {
+      "name": "EvtWithdrawMigrationFee",
+      "discriminator": [
+        26,
+        203,
+        84,
+        85,
+        161,
+        23,
+        100,
+        214
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "MathOverflow",
+      "msg": "Math operation overflow"
+    },
+    {
+      "code": 6001,
+      "name": "InvalidFee",
+      "msg": "Invalid fee setup"
+    },
+    {
+      "code": 6002,
+      "name": "ExceededSlippage",
+      "msg": "Exceeded slippage tolerance"
+    },
+    {
+      "code": 6003,
+      "name": "ExceedMaxFeeBps",
+      "msg": "Exceeded max fee bps"
+    },
+    {
+      "code": 6004,
+      "name": "InvalidAdmin",
+      "msg": "Invalid admin"
+    },
+    {
+      "code": 6005,
+      "name": "AmountIsZero",
+      "msg": "Amount is zero"
+    },
+    {
+      "code": 6006,
+      "name": "TypeCastFailed",
+      "msg": "Type cast error"
+    },
+    {
+      "code": 6007,
+      "name": "InvalidActivationType",
+      "msg": "Invalid activation type"
+    },
+    {
+      "code": 6008,
+      "name": "InvalidQuoteMint",
+      "msg": "Invalid quote mint"
+    },
+    {
+      "code": 6009,
+      "name": "InvalidCollectFeeMode",
+      "msg": "Invalid collect fee mode"
+    },
+    {
+      "code": 6010,
+      "name": "InvalidMigrationFeeOption",
+      "msg": "Invalid migration fee option"
+    },
+    {
+      "code": 6011,
+      "name": "InvalidInput",
+      "msg": "Invalid input"
+    },
+    {
+      "code": 6012,
+      "name": "NotEnoughLiquidity",
+      "msg": "Not enough liquidity"
+    },
+    {
+      "code": 6013,
+      "name": "PoolIsCompleted",
+      "msg": "Pool is completed"
+    },
+    {
+      "code": 6014,
+      "name": "PoolIsIncompleted",
+      "msg": "Pool is incompleted"
+    },
+    {
+      "code": 6015,
+      "name": "InvalidMigrationOption",
+      "msg": "Invalid migration option"
+    },
+    {
+      "code": 6016,
+      "name": "InvalidTokenDecimals",
+      "msg": "Invalid token decimals"
+    },
+    {
+      "code": 6017,
+      "name": "InvalidTokenType",
+      "msg": "Invalid token type"
+    },
+    {
+      "code": 6018,
+      "name": "InvalidFeePercentage",
+      "msg": "Invalid fee percentage"
+    },
+    {
+      "code": 6019,
+      "name": "InvalidQuoteThreshold",
+      "msg": "Invalid quote threshold"
+    },
+    {
+      "code": 6020,
+      "name": "InvalidTokenSupply",
+      "msg": "Invalid token supply"
+    },
+    {
+      "code": 6021,
+      "name": "InvalidCurve",
+      "msg": "Invalid curve"
+    },
+    {
+      "code": 6022,
+      "name": "NotPermitToDoThisAction",
+      "msg": "Not permit to do this action"
+    },
+    {
+      "code": 6023,
+      "name": "InvalidOwnerAccount",
+      "msg": "Invalid owner account"
+    },
+    {
+      "code": 6024,
+      "name": "InvalidConfigAccount",
+      "msg": "Invalid config account"
+    },
+    {
+      "code": 6025,
+      "name": "SurplusHasBeenWithdraw",
+      "msg": "Surplus has been withdraw"
+    },
+    {
+      "code": 6026,
+      "name": "LeftoverHasBeenWithdraw",
+      "msg": "Leftover has been withdraw"
+    },
+    {
+      "code": 6027,
+      "name": "TotalBaseTokenExceedMaxSupply",
+      "msg": "Total base token is exceeded max supply"
+    },
+    {
+      "code": 6028,
+      "name": "UnsupportNativeMintToken2022",
+      "msg": "Unsupport native mint token 2022"
+    },
+    {
+      "code": 6029,
+      "name": "InsufficientLiquidityForMigration",
+      "msg": "Insufficient liquidity for migration"
+    },
+    {
+      "code": 6030,
+      "name": "MissingPoolConfigInRemainingAccount",
+      "msg": "Missing pool config in remaining account"
+    },
+    {
+      "code": 6031,
+      "name": "InvalidVestingParameters",
+      "msg": "Invalid vesting parameters"
+    },
+    {
+      "code": 6032,
+      "name": "InvalidLeftoverAddress",
+      "msg": "Invalid leftover address"
+    },
+    {
+      "code": 6033,
+      "name": "InsufficientLiquidity",
+      "msg": "Liquidity in bonding curve is insufficient"
+    },
+    {
+      "code": 6034,
+      "name": "InvalidFeeScheduler",
+      "msg": "Invalid fee scheduler"
+    },
+    {
+      "code": 6035,
+      "name": "InvalidCreatorTradingFeePercentage",
+      "msg": "Invalid creator trading fee percentage"
+    },
+    {
+      "code": 6036,
+      "name": "InvalidNewCreator",
+      "msg": "Invalid new creator"
+    },
+    {
+      "code": 6037,
+      "name": "InvalidTokenAuthorityOption",
+      "msg": "Invalid token authority option"
+    },
+    {
+      "code": 6038,
+      "name": "InvalidAccount",
+      "msg": "Invalid account for the instruction"
+    },
+    {
+      "code": 6039,
+      "name": "InvalidMigratorFeePercentage",
+      "msg": "Invalid migrator fee percentage"
+    },
+    {
+      "code": 6040,
+      "name": "MigrationFeeHasBeenWithdraw",
+      "msg": "Migration fee has been withdraw"
+    },
+    {
+      "code": 6041,
+      "name": "InvalidBaseFeeMode",
+      "msg": "Invalid base fee mode"
+    },
+    {
+      "code": 6042,
+      "name": "InvalidFeeRateLimiter",
+      "msg": "Invalid fee rate limiter"
+    },
+    {
+      "code": 6043,
+      "name": "FailToValidateSingleSwapInstruction",
+      "msg": "Fail to validate single swap instruction in rate limiter"
+    },
+    {
+      "code": 6044,
+      "name": "InvalidMigratedPoolFee",
+      "msg": "Invalid migrated pool fee params"
+    },
+    {
+      "code": 6045,
+      "name": "UndeterminedError",
+      "msg": "Undertermined error"
+    },
+    {
+      "code": 6046,
+      "name": "RateLimiterNotSupported",
+      "msg": "Rate limiter not supported"
+    },
+    {
+      "code": 6047,
+      "name": "AmountLeftIsNotZero",
+      "msg": "Amount left is not zero"
+    },
+    {
+      "code": 6048,
+      "name": "NextSqrtPriceIsSmallerThanStartSqrtPrice",
+      "msg": "Next sqrt price is smaller than start sqrt price"
+    },
+    {
+      "code": 6049,
+      "name": "InvalidMinBaseFee",
+      "msg": "Invalid min base fee"
+    },
+    {
+      "code": 6050,
+      "name": "AccountInvariantViolation",
+      "msg": "Account invariant violation"
+    },
+    {
+      "code": 6051,
+      "name": "InvalidPoolCreationFee",
+      "msg": "Invalid pool creation fee"
+    },
+    {
+      "code": 6052,
+      "name": "PoolCreationFeeHasBeenClaimed",
+      "msg": "Pool creation fee has been claimed"
+    },
+    {
+      "code": 6053,
+      "name": "Unauthorized",
+      "msg": "Not permit to do this action"
+    },
+    {
+      "code": 6054,
+      "name": "ZeroPoolCreationFee",
+      "msg": "Pool creation fee is zero"
+    },
+    {
+      "code": 6055,
+      "name": "InvalidMigrationLockedLiquidity",
+      "msg": "Invalid migration locked liquidity"
+    },
+    {
+      "code": 6056,
+      "name": "InvalidFeeMarketCapScheduler",
+      "msg": "Invalid fee market cap scheduler"
+    },
+    {
+      "code": 6057,
+      "name": "FirstSwapValidationFailed",
+      "msg": "Fail to validate first swap with minimum fee"
+    },
+    {
+      "code": 6058,
+      "name": "IncorrectATA",
+      "msg": "Incorrect ATA"
+    },
+    {
+      "code": 6059,
+      "name": "InsufficientPoolLamports",
+      "msg": "Pool has insufficient lamports to perform the operation"
+    },
+    {
+      "code": 6060,
+      "name": "InvalidPermission",
+      "msg": "Invalid permission"
+    },
+    {
+      "code": 6061,
+      "name": "InvalidWithdrawProtocolFeeZapAccounts",
+      "msg": "Invalid withdraw protocol fee zap accounts"
+    },
+    {
+      "code": 6062,
+      "name": "MintRestrictedFromZap",
+      "msg": "SOL,USDC protocol fee cannot be withdrawn via zap"
+    },
+    {
+      "code": 6063,
+      "name": "InvalidZapOutParameters",
+      "msg": "Invalid zap out parameters"
+    },
+    {
+      "code": 6064,
+      "name": "CpiDisabled",
+      "msg": "CPI disabled"
+    },
+    {
+      "code": 6065,
+      "name": "MissingZapOutInstruction",
+      "msg": "Missing zap out instruction"
+    },
+    {
+      "code": 6066,
+      "name": "InvalidZapAccounts",
+      "msg": "Invalid zap accounts"
+    },
+    {
+      "code": 6067,
+      "name": "InvalidCompoundingParameters",
+      "msg": "Invalid compounding parameters"
+    },
+    {
+      "code": 6068,
+      "name": "InvalidClaimProtocolFeeAccounts",
+      "msg": "Invalid claim protocol fee accounts"
+    },
+    {
+      "code": 6069,
+      "name": "InvalidInstructionsSysvar",
+      "msg": "Invalid instructions sysvar account"
+    },
+    {
+      "code": 6070,
+      "name": "InvalidRemainingAccountsLength",
+      "msg": "Invalid remaining accounts length"
+    },
+    {
+      "code": 6071,
+      "name": "MissingRemainingAccountForTransferHook",
+      "msg": "Missing remaining account for transfer hook"
+    },
+    {
+      "code": 6072,
+      "name": "NoTransferHookProgram",
+      "msg": "No transfer hook program"
+    },
+    {
+      "code": 6073,
+      "name": "DuplicatedRemainingAccountTypes",
+      "msg": "Duplicated remaining account types"
+    },
+    {
+      "code": 6074,
+      "name": "InvalidTransferHookProgram",
+      "msg": "Invalid transfer hook program"
+    },
+    {
+      "code": 6075,
+      "name": "InvalidPoolAccount",
+      "msg": "Invalid pool account"
+    },
+    {
+      "code": 6076,
+      "name": "PoolTypeMismatch",
+      "msg": "Pool type does not match instruction"
+    }
+  ],
+  "types": [
+    {
+      "name": "AccountsType",
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "TransferHookBase"
+          },
+          {
+            "name": "TransferHookBaseReferral"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BaseFeeConfig",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "cliff_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "second_factor",
+            "type": "u64"
+          },
+          {
+            "name": "third_factor",
+            "type": "u64"
+          },
+          {
+            "name": "first_factor",
+            "type": "u16"
+          },
+          {
+            "name": "base_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "padding_0",
+            "type": {
+              "array": [
+                "u8",
+                5
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BaseFeeParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "cliff_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "first_factor",
+            "type": "u16"
+          },
+          {
+            "name": "second_factor",
+            "type": "u64"
+          },
+          {
+            "name": "third_factor",
+            "type": "u64"
+          },
+          {
+            "name": "base_fee_mode",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ClaimFeeOperator",
+      "docs": [
+        "Parameter that set by the protocol"
+      ],
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "operator",
+            "docs": [
+              "operator"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "_padding",
+            "docs": [
+              "Reserve"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                128
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Config",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_fees",
+            "type": {
+              "defined": {
+                "name": "PoolFees"
+              }
+            }
+          },
+          {
+            "name": "activation_duration",
+            "type": "u64"
+          },
+          {
+            "name": "vault_config_key",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_creator_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "activation_type",
+            "type": "u8"
+          },
+          {
+            "name": "partner_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                219
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConfigParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_fees",
+            "type": {
+              "defined": {
+                "name": "PoolFeeParameters"
+              }
+            }
+          },
+          {
+            "name": "collect_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "migration_option",
+            "type": "u8"
+          },
+          {
+            "name": "activation_type",
+            "type": "u8"
+          },
+          {
+            "name": "token_type",
+            "type": "u8"
+          },
+          {
+            "name": "token_decimal",
+            "type": "u8"
+          },
+          {
+            "name": "partner_liquidity_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "partner_permanent_locked_liquidity_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "creator_liquidity_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "creator_permanent_locked_liquidity_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "migration_quote_threshold",
+            "type": "u64"
+          },
+          {
+            "name": "sqrt_start_price",
+            "type": "u128"
+          },
+          {
+            "name": "locked_vesting",
+            "type": {
+              "defined": {
+                "name": "LockedVestingParams"
+              }
+            }
+          },
+          {
+            "name": "migration_fee_option",
+            "type": "u8"
+          },
+          {
+            "name": "token_supply",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "TokenSupplyParams"
+                }
+              }
+            }
+          },
+          {
+            "name": "creator_trading_fee_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "token_update_authority",
+            "type": "u8"
+          },
+          {
+            "name": "migration_fee",
+            "type": {
+              "defined": {
+                "name": "MigrationFee"
+              }
+            }
+          },
+          {
+            "name": "migrated_pool_fee",
+            "type": {
+              "defined": {
+                "name": "MigratedPoolFee"
+              }
+            }
+          },
+          {
+            "name": "pool_creation_fee",
+            "docs": [
+              "pool creation fee in SOL lamports value"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "partner_liquidity_vesting_info",
+            "type": {
+              "defined": {
+                "name": "LiquidityVestingInfoParams"
+              }
+            }
+          },
+          {
+            "name": "creator_liquidity_vesting_info",
+            "type": {
+              "defined": {
+                "name": "LiquidityVestingInfoParams"
+              }
+            }
+          },
+          {
+            "name": "migrated_pool_base_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "migrated_pool_market_cap_fee_scheduler_params",
+            "type": {
+              "defined": {
+                "name": "MigratedPoolMarketCapFeeSchedulerParams"
+              }
+            }
+          },
+          {
+            "name": "enable_first_swap_with_min_fee",
+            "type": "bool"
+          },
+          {
+            "name": "compounding_fee_bps",
+            "type": "u16"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding for future use"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                2
+              ]
+            }
+          },
+          {
+            "name": "curve",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "LiquidityDistributionParameters"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConfigWithTransferHook",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "config",
+            "type": {
+              "defined": {
+                "name": "PoolConfig"
+              }
+            }
+          },
+          {
+            "name": "transfer_hook_program",
+            "type": "pubkey"
+          },
+          {
+            "name": "padding_0",
+            "type": {
+              "array": [
+                "u64",
+                6
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreatePartnerMetadataParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                96
+              ]
+            }
+          },
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "website",
+            "type": "string"
+          },
+          {
+            "name": "logo",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreateVirtualPoolMetadataParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                96
+              ]
+            }
+          },
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "website",
+            "type": "string"
+          },
+          {
+            "name": "logo",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DynamicFeeConfig",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "initialized",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                7
+              ]
+            }
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "type": "u32"
+          },
+          {
+            "name": "variable_fee_control",
+            "type": "u32"
+          },
+          {
+            "name": "bin_step",
+            "type": "u16"
+          },
+          {
+            "name": "filter_period",
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "type": "u16"
+          },
+          {
+            "name": "padding2",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "name": "bin_step_u128",
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DynamicFeeParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bin_step",
+            "type": "u16"
+          },
+          {
+            "name": "bin_step_u128",
+            "type": "u128"
+          },
+          {
+            "name": "filter_period",
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "type": "u16"
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "type": "u32"
+          },
+          {
+            "name": "variable_fee_control",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtClaimCreatorTradingFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_base_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_quote_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtClaimPoolCreationFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "receiver",
+            "type": "pubkey"
+          },
+          {
+            "name": "creation_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtClaimProtocolFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_base_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_quote_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtClaimProtocolFee2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "receiver_token_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtClaimTradingFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_base_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_quote_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtCloseClaimFeeOperator",
+      "docs": [
+        "Close claim fee operator"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "claim_fee_operator",
+            "type": "pubkey"
+          },
+          {
+            "name": "operator",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtCreateClaimFeeOperator",
+      "docs": [
+        "Create claim fee operator"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "operator",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtCreateConfig",
+      "docs": [
+        "Create config"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "quote_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_claimer",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_fees",
+            "type": {
+              "defined": {
+                "name": "PoolFeeParameters"
+              }
+            }
+          },
+          {
+            "name": "collect_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "migration_option",
+            "type": "u8"
+          },
+          {
+            "name": "activation_type",
+            "type": "u8"
+          },
+          {
+            "name": "token_decimal",
+            "type": "u8"
+          },
+          {
+            "name": "token_type",
+            "type": "u8"
+          },
+          {
+            "name": "partner_permanent_locked_liquidity_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "partner_liquidity_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "creator_permanent_locked_liquidity_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "creator_liquidity_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "swap_base_amount",
+            "type": "u64"
+          },
+          {
+            "name": "migration_quote_threshold",
+            "type": "u64"
+          },
+          {
+            "name": "migration_base_amount",
+            "type": "u64"
+          },
+          {
+            "name": "sqrt_start_price",
+            "type": "u128"
+          },
+          {
+            "name": "locked_vesting",
+            "type": {
+              "defined": {
+                "name": "LockedVestingParams"
+              }
+            }
+          },
+          {
+            "name": "migration_fee_option",
+            "type": "u8"
+          },
+          {
+            "name": "fixed_token_supply_flag",
+            "type": "u8"
+          },
+          {
+            "name": "pre_migration_token_supply",
+            "type": "u64"
+          },
+          {
+            "name": "post_migration_token_supply",
+            "type": "u64"
+          },
+          {
+            "name": "curve",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "LiquidityDistributionParameters"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtCreateConfigV2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "quote_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_claimer",
+            "type": "pubkey"
+          },
+          {
+            "name": "leftover_receiver",
+            "type": "pubkey"
+          },
+          {
+            "name": "config_parameters",
+            "type": {
+              "defined": {
+                "name": "ConfigParameters"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtCreateConfigV2WithTransferHook",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "quote_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_claimer",
+            "type": "pubkey"
+          },
+          {
+            "name": "leftover_receiver",
+            "type": "pubkey"
+          },
+          {
+            "name": "config_parameters",
+            "type": {
+              "defined": {
+                "name": "ConfigParameters"
+              }
+            }
+          },
+          {
+            "name": "transfer_hook_program",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtCreateMeteoraMigrationMetadata",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "virtual_pool",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtCreatorWithdrawSurplus",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "surplus_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtCurveComplete",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "base_reserve",
+            "type": "u64"
+          },
+          {
+            "name": "quote_reserve",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtCurveCompleteWithTransferHook",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "base_reserve",
+            "type": "u64"
+          },
+          {
+            "name": "quote_reserve",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtInitializePool",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "creator",
+            "type": "pubkey"
+          },
+          {
+            "name": "base_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_type",
+            "type": "u8"
+          },
+          {
+            "name": "activation_point",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtInitializePoolWithTransferHook",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "creator",
+            "type": "pubkey"
+          },
+          {
+            "name": "base_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_type",
+            "type": "u8"
+          },
+          {
+            "name": "activation_point",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtPartnerClaimPoolCreationFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "partner",
+            "type": "pubkey"
+          },
+          {
+            "name": "creation_fee",
+            "type": "u64"
+          },
+          {
+            "name": "fee_receiver",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtPartnerMetadata",
+      "docs": [
+        "Create partner metadata"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "partner_metadata",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_claimer",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtPartnerWithdrawSurplus",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "surplus_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtSwap",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "trade_direction",
+            "type": "u8"
+          },
+          {
+            "name": "has_referral",
+            "type": "bool"
+          },
+          {
+            "name": "params",
+            "type": {
+              "defined": {
+                "name": "SwapParameters"
+              }
+            }
+          },
+          {
+            "name": "swap_result",
+            "type": {
+              "defined": {
+                "name": "SwapResult"
+              }
+            }
+          },
+          {
+            "name": "amount_in",
+            "type": "u64"
+          },
+          {
+            "name": "current_timestamp",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtSwap2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "trade_direction",
+            "type": "u8"
+          },
+          {
+            "name": "has_referral",
+            "type": "bool"
+          },
+          {
+            "name": "swap_parameters",
+            "type": {
+              "defined": {
+                "name": "SwapParameters2"
+              }
+            }
+          },
+          {
+            "name": "swap_result",
+            "type": {
+              "defined": {
+                "name": "SwapResult2"
+              }
+            }
+          },
+          {
+            "name": "quote_reserve_amount",
+            "type": "u64"
+          },
+          {
+            "name": "migration_threshold",
+            "type": "u64"
+          },
+          {
+            "name": "current_timestamp",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtSwap2WithTransferHook",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "trade_direction",
+            "type": "u8"
+          },
+          {
+            "name": "has_referral",
+            "type": "bool"
+          },
+          {
+            "name": "swap_parameters",
+            "type": {
+              "defined": {
+                "name": "SwapParameters2"
+              }
+            }
+          },
+          {
+            "name": "swap_result",
+            "type": {
+              "defined": {
+                "name": "SwapResult2"
+              }
+            }
+          },
+          {
+            "name": "quote_reserve_amount",
+            "type": "u64"
+          },
+          {
+            "name": "migration_threshold",
+            "type": "u64"
+          },
+          {
+            "name": "current_timestamp",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtUpdatePoolCreator",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "creator",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_creator",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtVirtualPoolMetadata",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "virtual_pool_metadata",
+            "type": "pubkey"
+          },
+          {
+            "name": "virtual_pool",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtWithdrawLeftover",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "leftover_receiver",
+            "type": "pubkey"
+          },
+          {
+            "name": "leftover_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtWithdrawMigrationFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee",
+            "type": "u64"
+          },
+          {
+            "name": "flag",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "InitializePoolParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "name": "symbol",
+            "type": "string"
+          },
+          {
+            "name": "uri",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityDistributionConfig",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "sqrt_price",
+            "type": "u128"
+          },
+          {
+            "name": "liquidity",
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityDistributionParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "sqrt_price",
+            "type": "u128"
+          },
+          {
+            "name": "liquidity",
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityVestingInfo",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "is_initialized",
+            "type": "u8"
+          },
+          {
+            "name": "vesting_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "_padding",
+            "type": {
+              "array": [
+                "u8",
+                2
+              ]
+            }
+          },
+          {
+            "name": "bps_per_period",
+            "type": "u16"
+          },
+          {
+            "name": "number_of_periods",
+            "type": "u16"
+          },
+          {
+            "name": "frequency",
+            "type": "u32"
+          },
+          {
+            "name": "cliff_duration_from_migration_time",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityVestingInfoParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vesting_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "bps_per_period",
+            "type": "u16"
+          },
+          {
+            "name": "number_of_periods",
+            "type": "u16"
+          },
+          {
+            "name": "cliff_duration_from_migration_time",
+            "type": "u32"
+          },
+          {
+            "name": "frequency",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LockEscrow",
+      "docs": [
+        "State of lock escrow account"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "escrow_vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "total_locked_amount",
+            "type": "u64"
+          },
+          {
+            "name": "lp_per_token",
+            "type": "u128"
+          },
+          {
+            "name": "unclaimed_fee_pending",
+            "type": "u64"
+          },
+          {
+            "name": "a_fee",
+            "type": "u64"
+          },
+          {
+            "name": "b_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LockedVestingConfig",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_per_period",
+            "type": "u64"
+          },
+          {
+            "name": "cliff_duration_from_migration_time",
+            "type": "u64"
+          },
+          {
+            "name": "frequency",
+            "type": "u64"
+          },
+          {
+            "name": "number_of_period",
+            "type": "u64"
+          },
+          {
+            "name": "cliff_unlock_amount",
+            "type": "u64"
+          },
+          {
+            "name": "_padding",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LockedVestingParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_per_period",
+            "type": "u64"
+          },
+          {
+            "name": "cliff_duration_from_migration_time",
+            "type": "u64"
+          },
+          {
+            "name": "frequency",
+            "type": "u64"
+          },
+          {
+            "name": "number_of_period",
+            "type": "u64"
+          },
+          {
+            "name": "cliff_unlock_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MeteoraDammMigrationMetadata",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "virtual_pool",
+            "docs": [
+              "pool"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "padding_0",
+            "docs": [
+              "!!! BE CAREFUL to use tombstone field, previous is pool creator"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "partner",
+            "docs": [
+              "partner"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "lp_mint",
+            "docs": [
+              "lp mint"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "partner_locked_liquidity",
+            "docs": [
+              "partner locked liquidity"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "partner_liquidity",
+            "docs": [
+              "partner liquidity"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "creator_locked_liquidity",
+            "docs": [
+              "creator locked liquidity"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "creator_liquidity",
+            "docs": [
+              "creator liquidity"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "_padding_0",
+            "docs": [
+              "padding"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "creator_locked_status",
+            "docs": [
+              "flag to check whether liquidity token is locked for creator"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "partner_locked_status",
+            "docs": [
+              "flag to check whether liquidity token is locked for partner"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "creator_claim_status",
+            "docs": [
+              "flag to check whether creator has claimed liquidity token"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "partner_claim_status",
+            "docs": [
+              "flag to check whether partner has claimed liquidity token"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "_padding",
+            "docs": [
+              "Reserve"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                107
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MigratedPoolFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "collect_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "dynamic_fee",
+            "type": "u8"
+          },
+          {
+            "name": "pool_fee_bps",
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MigratedPoolMarketCapFeeSchedulerParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "number_of_period",
+            "type": "u16"
+          },
+          {
+            "name": "sqrt_price_step_bps",
+            "type": "u16"
+          },
+          {
+            "name": "scheduler_expiration_duration",
+            "type": "u32"
+          },
+          {
+            "name": "reduction_factor",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MigrationFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "fee_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "creator_fee_percentage",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Operator",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "whitelisted_address",
+            "type": "pubkey"
+          },
+          {
+            "name": "permission",
+            "type": "u128"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                2
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PartnerMetadata",
+      "docs": [
+        "Metadata for a partner."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "fee_claimer",
+            "docs": [
+              "fee claimer"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding for future use"
+            ],
+            "type": {
+              "array": [
+                "u128",
+                6
+              ]
+            }
+          },
+          {
+            "name": "name",
+            "docs": [
+              "Name of partner."
+            ],
+            "type": "string"
+          },
+          {
+            "name": "website",
+            "docs": [
+              "Website of partner."
+            ],
+            "type": "string"
+          },
+          {
+            "name": "logo",
+            "docs": [
+              "Logo of partner"
+            ],
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolConfig",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "quote_mint",
+            "docs": [
+              "quote mint"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_claimer",
+            "docs": [
+              "Address to get the fee"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "leftover_receiver",
+            "docs": [
+              "Address to receive extra base token after migration, in case token is fixed supply"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_fees",
+            "docs": [
+              "Pool fee"
+            ],
+            "type": {
+              "defined": {
+                "name": "PoolFeesConfig"
+              }
+            }
+          },
+          {
+            "name": "partner_liquidity_vesting_info",
+            "type": {
+              "defined": {
+                "name": "LiquidityVestingInfo"
+              }
+            }
+          },
+          {
+            "name": "creator_liquidity_vesting_info",
+            "type": {
+              "defined": {
+                "name": "LiquidityVestingInfo"
+              }
+            }
+          },
+          {
+            "name": "padding_0",
+            "docs": [
+              "Padding for future use"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                14
+              ]
+            }
+          },
+          {
+            "name": "padding_1",
+            "docs": [
+              "Previously was protocol and referral fee percent. Beware of tombstone."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "collect_fee_mode",
+            "docs": [
+              "Collect fee mode"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "migration_option",
+            "docs": [
+              "migration option"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "activation_type",
+            "docs": [
+              "whether mode slot or timestamp"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "token_decimal",
+            "docs": [
+              "token decimals"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "version",
+            "docs": [
+              "version"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "token_type",
+            "docs": [
+              "token type of base token"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "quote_token_flag",
+            "docs": [
+              "quote token flag"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "partner_permanent_locked_liquidity_percentage",
+            "docs": [
+              "partner locked liquidity percentage"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "partner_liquidity_percentage",
+            "docs": [
+              "partner liquidity percentage"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "creator_permanent_locked_liquidity_percentage",
+            "docs": [
+              "creator post migration fee percentage"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "creator_liquidity_percentage",
+            "docs": [
+              "creator liquidity percentage"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "migration_fee_option",
+            "docs": [
+              "migration fee option"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "fixed_token_supply_flag",
+            "docs": [
+              "flag to indicate whether token is dynamic supply (0) or fixed supply (1)"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "creator_trading_fee_percentage",
+            "docs": [
+              "creator trading fee percentage"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "token_update_authority",
+            "docs": [
+              "token update authority"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "migration_fee_percentage",
+            "docs": [
+              "migration fee percentage"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "creator_migration_fee_percentage",
+            "docs": [
+              "creator migration fee percentage"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding_2",
+            "type": {
+              "array": [
+                "u8",
+                7
+              ]
+            }
+          },
+          {
+            "name": "swap_base_amount",
+            "docs": [
+              "swap base amount"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "migration_quote_threshold",
+            "docs": [
+              "migration quote threshold (in quote token)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "migration_base_threshold",
+            "docs": [
+              "migration base threshold (in base token)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "migration_sqrt_price",
+            "docs": [
+              "migration sqrt price"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "locked_vesting_config",
+            "docs": [
+              "locked vesting config"
+            ],
+            "type": {
+              "defined": {
+                "name": "LockedVestingConfig"
+              }
+            }
+          },
+          {
+            "name": "pre_migration_token_supply",
+            "docs": [
+              "pre migration token supply"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "post_migration_token_supply",
+            "docs": [
+              "post migration token supply"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "migrated_collect_fee_mode",
+            "docs": [
+              "migrated pool collect fee mode"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "migrated_dynamic_fee",
+            "docs": [
+              "migrated dynamic fee option."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "migrated_pool_fee_bps",
+            "docs": [
+              "migrated pool fee in bps"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "migrated_pool_base_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "enable_first_swap_with_min_fee",
+            "type": "u8"
+          },
+          {
+            "name": "migrated_compounding_fee_bps",
+            "docs": [
+              "compounding fee bps for migrated DAMM v2 pool, should only be non-zero if migrated_collect_fee_mode is 2 (Compounding)"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "pool_creation_fee",
+            "docs": [
+              "pool creation fee in lamports value"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "migrated_pool_base_fee_bytes",
+            "docs": [
+              "serialized MigratedPoolMarketCapFeeSchedulerParams, only used when migrated_pool_base_fee_mode is market cap scheduler"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "name": "sqrt_start_price",
+            "docs": [
+              "minimum price"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "curve",
+            "docs": [
+              "curve, only use 20 point firstly, we can extend that latter"
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "LiquidityDistributionConfig"
+                  }
+                },
+                20
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolFeeParameters",
+      "docs": [
+        "Information regarding fee charges"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "base_fee",
+            "docs": [
+              "Base fee"
+            ],
+            "type": {
+              "defined": {
+                "name": "BaseFeeParameters"
+              }
+            }
+          },
+          {
+            "name": "dynamic_fee",
+            "docs": [
+              "dynamic fee"
+            ],
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "DynamicFeeParameters"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolFees",
+      "docs": [
+        "Information regarding fee charges"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "trade_fee_denominator",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_denominator",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolFeesConfig",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "base_fee",
+            "type": {
+              "defined": {
+                "name": "BaseFeeConfig"
+              }
+            }
+          },
+          {
+            "name": "dynamic_fee",
+            "type": {
+              "defined": {
+                "name": "DynamicFeeConfig"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolMetrics",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "total_protocol_base_fee",
+            "type": "u64"
+          },
+          {
+            "name": "total_protocol_quote_fee",
+            "type": "u64"
+          },
+          {
+            "name": "total_trading_base_fee",
+            "type": "u64"
+          },
+          {
+            "name": "total_trading_quote_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolState",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "volatility_tracker",
+            "docs": [
+              "volatility tracker"
+            ],
+            "type": {
+              "defined": {
+                "name": "VolatilityTracker"
+              }
+            }
+          },
+          {
+            "name": "config",
+            "docs": [
+              "config key"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "creator",
+            "docs": [
+              "creator"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "base_mint",
+            "docs": [
+              "base mint"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "base_vault",
+            "docs": [
+              "base vault"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "quote_vault",
+            "docs": [
+              "quote vault"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "base_reserve",
+            "docs": [
+              "base reserve"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "quote_reserve",
+            "docs": [
+              "quote reserve"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "protocol_base_fee",
+            "docs": [
+              "protocol base fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "protocol_quote_fee",
+            "docs": [
+              "protocol quote fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "partner_base_fee",
+            "docs": [
+              "partner base fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "partner_quote_fee",
+            "docs": [
+              "trading quote fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "sqrt_price",
+            "docs": [
+              "current price"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "activation_point",
+            "docs": [
+              "Activation point"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "pool_type",
+            "docs": [
+              "pool type, spl token or token2022"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "is_migrated",
+            "docs": [
+              "is migrated"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "is_partner_withdraw_surplus",
+            "docs": [
+              "is partner withdraw surplus"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "is_protocol_withdraw_surplus",
+            "docs": [
+              "is protocol withdraw surplus"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "migration_progress",
+            "docs": [
+              "migration progress"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "is_withdraw_leftover",
+            "docs": [
+              "is withdraw leftover"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "is_creator_withdraw_surplus",
+            "docs": [
+              "is creator withdraw surplus"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "migration_fee_withdraw_status",
+            "docs": [
+              "migration fee withdraw status",
+              "bit 1 (0b010) creator",
+              "bit 2 (0b100) partner"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "metrics",
+            "docs": [
+              "pool metrics"
+            ],
+            "type": {
+              "defined": {
+                "name": "PoolMetrics"
+              }
+            }
+          },
+          {
+            "name": "finish_curve_timestamp",
+            "docs": [
+              "The time curve is finished"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "creator_base_fee",
+            "docs": [
+              "creator base fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "creator_quote_fee",
+            "docs": [
+              "creator quote fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "legacy_creation_fee_bits",
+            "docs": [
+              "legacy creation fee bits, we dont use this now"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "creation_fee_bits",
+            "docs": [
+              "pool creation fee claim status"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "has_swap",
+            "docs": [
+              "Cached flag"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "_padding_0",
+            "docs": [
+              "Padding for further use"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                5
+              ]
+            }
+          },
+          {
+            "name": "protocol_liquidity_migration_fee_bps",
+            "type": "u16"
+          },
+          {
+            "name": "_padding_1",
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          },
+          {
+            "name": "protocol_migration_base_fee_amount",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_migration_quote_fee_amount",
+            "type": "u64"
+          },
+          {
+            "name": "_padding_2",
+            "docs": [
+              "Padding for further use"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                3
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "RemainingAccountsSlice",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "accounts_type",
+            "type": {
+              "defined": {
+                "name": "AccountsType"
+              }
+            }
+          },
+          {
+            "name": "length",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwapParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_in",
+            "type": "u64"
+          },
+          {
+            "name": "minimum_amount_out",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwapParameters2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_0",
+            "docs": [
+              "When it's exact in, partial fill, this will be amount_in. When it's exact out, this will be amount_out"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "amount_1",
+            "docs": [
+              "When it's exact in, partial fill, this will be minimum_amount_out. When it's exact out, this will be maximum_amount_in"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "swap_mode",
+            "docs": [
+              "Swap mode, refer [SwapMode]"
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwapResult",
+      "docs": [
+        "Encodes all results of swapping"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "actual_input_amount",
+            "type": "u64"
+          },
+          {
+            "name": "output_amount",
+            "type": "u64"
+          },
+          {
+            "name": "next_sqrt_price",
+            "type": "u128"
+          },
+          {
+            "name": "trading_fee",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fee",
+            "type": "u64"
+          },
+          {
+            "name": "referral_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwapResult2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "included_fee_input_amount",
+            "type": "u64"
+          },
+          {
+            "name": "excluded_fee_input_amount",
+            "type": "u64"
+          },
+          {
+            "name": "amount_left",
+            "type": "u64"
+          },
+          {
+            "name": "output_amount",
+            "type": "u64"
+          },
+          {
+            "name": "next_sqrt_price",
+            "type": "u128"
+          },
+          {
+            "name": "trading_fee",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fee",
+            "type": "u64"
+          },
+          {
+            "name": "referral_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenSupplyParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pre_migration_token_supply",
+            "docs": [
+              "pre migration token supply"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "post_migration_token_supply",
+            "docs": [
+              "post migration token supply",
+              "because DBC allow user to swap over the migration quote threshold, so in extreme case user may swap more than allowed buffer on curve",
+              "that result the total supply in post migration may be increased a bit (between pre_migration_token_supply and post_migration_token_supply)"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TransferHookAccountsInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "slices",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "RemainingAccountsSlice"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TransferHookPool",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_state",
+            "type": {
+              "defined": {
+                "name": "PoolState"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "VirtualPool",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_state",
+            "type": {
+              "defined": {
+                "name": "PoolState"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "VirtualPoolMetadata",
+      "docs": [
+        "Metadata for a virtual pool."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "virtual_pool",
+            "docs": [
+              "virtual pool"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding for future use"
+            ],
+            "type": {
+              "array": [
+                "u128",
+                6
+              ]
+            }
+          },
+          {
+            "name": "name",
+            "docs": [
+              "Name of project."
+            ],
+            "type": "string"
+          },
+          {
+            "name": "website",
+            "docs": [
+              "Website of project."
+            ],
+            "type": "string"
+          },
+          {
+            "name": "logo",
+            "docs": [
+              "Logo of project"
+            ],
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VolatilityTracker",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "last_update_timestamp",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "name": "sqrt_price_reference",
+            "type": "u128"
+          },
+          {
+            "name": "volatility_accumulator",
+            "type": "u128"
+          },
+          {
+            "name": "volatility_reference",
+            "type": "u128"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/idl/orca_whirlpool.json
+++ b/idl/orca_whirlpool.json
@@ -1,4326 +1,7608 @@
 {
-  "version": "0.3.6",
-  "name": "whirlpool",
-  "instructions": [
-    {
-      "name": "initializeConfig",
-      "accounts": [
-        {
-          "name": "config",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "feeAuthority",
-          "type": "publicKey"
-        },
-        {
-          "name": "collectProtocolFeesAuthority",
-          "type": "publicKey"
-        },
-        {
-          "name": "rewardEmissionsSuperAuthority",
-          "type": "publicKey"
-        },
-        {
-          "name": "defaultProtocolFeeRate",
-          "type": "u16"
-        }
-      ]
+    "address": "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc",
+    "metadata": {
+        "name": "whirlpool",
+        "version": "0.9.0",
+        "spec": "0.1.0"
     },
-    {
-      "name": "initializePool",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "feeTier",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "bumps",
-          "type": {
-            "defined": "WhirlpoolBumps"
-          }
-        },
-        {
-          "name": "tickSpacing",
-          "type": "u16"
-        },
-        {
-          "name": "initialSqrtPrice",
-          "type": "u128"
-        }
-      ]
-    },
-    {
-      "name": "initializeTickArray",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tickArray",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "startTickIndex",
-          "type": "i32"
-        }
-      ]
-    },
-    {
-      "name": "initializeFeeTier",
-      "accounts": [
-        {
-          "name": "config",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "feeTier",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "tickSpacing",
-          "type": "u16"
-        },
-        {
-          "name": "defaultFeeRate",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "initializeReward",
-      "accounts": [
-        {
-          "name": "rewardAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "setRewardEmissions",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "rewardVault",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        },
-        {
-          "name": "emissionsPerSecondX64",
-          "type": "u128"
-        }
-      ]
-    },
-    {
-      "name": "openPosition",
-      "accounts": [
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionMint",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "bumps",
-          "type": {
-            "defined": "OpenPositionBumps"
-          }
-        },
-        {
-          "name": "tickLowerIndex",
-          "type": "i32"
-        },
-        {
-          "name": "tickUpperIndex",
-          "type": "i32"
-        }
-      ]
-    },
-    {
-      "name": "openPositionWithMetadata",
-      "accounts": [
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionMint",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionMetadataAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "metadataProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "metadataUpdateAuth",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "bumps",
-          "type": {
-            "defined": "OpenPositionWithMetadataBumps"
-          }
-        },
-        {
-          "name": "tickLowerIndex",
-          "type": "i32"
-        },
-        {
-          "name": "tickUpperIndex",
-          "type": "i32"
-        }
-      ]
-    },
-    {
-      "name": "increaseLiquidity",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityAmount",
-          "type": "u128"
-        },
-        {
-          "name": "tokenMaxA",
-          "type": "u64"
-        },
-        {
-          "name": "tokenMaxB",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "decreaseLiquidity",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityAmount",
-          "type": "u128"
-        },
-        {
-          "name": "tokenMinA",
-          "type": "u64"
-        },
-        {
-          "name": "tokenMinB",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "updateFeesAndRewards",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayLower",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayUpper",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "collectFees",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "collectReward",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rewardOwnerAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "collectProtocolFees",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "collectProtocolFeesAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenDestinationA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenDestinationB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "swap",
-      "accounts": [
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArray0",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArray1",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArray2",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "amount",
-          "type": "u64"
-        },
-        {
-          "name": "otherAmountThreshold",
-          "type": "u64"
-        },
-        {
-          "name": "sqrtPriceLimit",
-          "type": "u128"
-        },
-        {
-          "name": "amountSpecifiedIsInput",
-          "type": "bool"
-        },
-        {
-          "name": "aToB",
-          "type": "bool"
-        }
-      ]
-    },
-    {
-      "name": "closePosition",
-      "accounts": [
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "receiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionMint",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setDefaultFeeRate",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "feeTier",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "defaultFeeRate",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "setDefaultProtocolFeeRate",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "defaultProtocolFeeRate",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "setFeeRate",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "feeRate",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "setProtocolFeeRate",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "protocolFeeRate",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "setFeeAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newFeeAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setCollectProtocolFeesAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "collectProtocolFeesAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newCollectProtocolFeesAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setRewardAuthority",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newRewardAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "setRewardAuthorityBySuperAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardEmissionsSuperAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newRewardAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "setRewardEmissionsSuperAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardEmissionsSuperAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newRewardEmissionsSuperAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "twoHopSwap",
-      "accounts": [
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpoolOne",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpoolTwo",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountOneA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultOneA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountOneB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultOneB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountTwoA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultTwoA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountTwoB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultTwoB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayOne0",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayOne1",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayOne2",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayTwo0",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayTwo1",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayTwo2",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracleOne",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "oracleTwo",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "amount",
-          "type": "u64"
-        },
-        {
-          "name": "otherAmountThreshold",
-          "type": "u64"
-        },
-        {
-          "name": "amountSpecifiedIsInput",
-          "type": "bool"
-        },
-        {
-          "name": "aToBOne",
-          "type": "bool"
-        },
-        {
-          "name": "aToBTwo",
-          "type": "bool"
-        },
-        {
-          "name": "sqrtPriceLimitOne",
-          "type": "u128"
-        },
-        {
-          "name": "sqrtPriceLimitTwo",
-          "type": "u128"
-        }
-      ]
-    },
-    {
-      "name": "initializePositionBundle",
-      "accounts": [
-        {
-          "name": "positionBundle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleMint",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionBundleTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleOwner",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "initializePositionBundleWithMetadata",
-      "accounts": [
-        {
-          "name": "positionBundle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleMint",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionBundleMetadata",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleOwner",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "metadataUpdateAuth",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "metadataProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "deletePositionBundle",
-      "accounts": [
-        {
-          "name": "positionBundle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleMint",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleOwner",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "receiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "openBundledPosition",
-      "accounts": [
-        {
-          "name": "bundledPosition",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "bundleIndex",
-          "type": "u16"
-        },
-        {
-          "name": "tickLowerIndex",
-          "type": "i32"
-        },
-        {
-          "name": "tickUpperIndex",
-          "type": "i32"
-        }
-      ]
-    },
-    {
-      "name": "closeBundledPosition",
-      "accounts": [
-        {
-          "name": "bundledPosition",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "receiver",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "bundleIndex",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "openPositionWithTokenExtensions",
-      "accounts": [
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionMint",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "token2022Program",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "metadataUpdateAuth",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "tickLowerIndex",
-          "type": "i32"
-        },
-        {
-          "name": "tickUpperIndex",
-          "type": "i32"
-        },
-        {
-          "name": "withTokenMetadataExtension",
-          "type": "bool"
-        }
-      ]
-    },
-    {
-      "name": "closePositionWithTokenExtensions",
-      "accounts": [
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "receiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionMint",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "token2022Program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "lockPosition",
-      "accounts": [
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lockConfig",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "token2022Program",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "lockType",
-          "type": {
-            "defined": "LockType"
-          }
-        }
-      ]
-    },
-    {
-      "name": "resetPositionRange",
-      "accounts": [
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "newTickLowerIndex",
-          "type": "i32"
-        },
-        {
-          "name": "newTickUpperIndex",
-          "type": "i32"
-        }
-      ]
-    },
-    {
-      "name": "transferLockedPosition",
-      "accounts": [
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "receiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "destinationTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lockConfig",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "token2022Program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "initializeAdaptiveFeeTier",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "adaptiveFeeTier",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "feeTierIndex",
-          "type": "u16"
-        },
-        {
-          "name": "tickSpacing",
-          "type": "u16"
-        },
-        {
-          "name": "initializePoolAuthority",
-          "type": "publicKey"
-        },
-        {
-          "name": "delegatedFeeAuthority",
-          "type": "publicKey"
-        },
-        {
-          "name": "defaultBaseFeeRate",
-          "type": "u16"
-        },
-        {
-          "name": "filterPeriod",
-          "type": "u16"
-        },
-        {
-          "name": "decayPeriod",
-          "type": "u16"
-        },
-        {
-          "name": "reductionFactor",
-          "type": "u16"
-        },
-        {
-          "name": "adaptiveFeeControlFactor",
-          "type": "u32"
-        },
-        {
-          "name": "maxVolatilityAccumulator",
-          "type": "u32"
-        },
-        {
-          "name": "tickGroupSize",
-          "type": "u16"
-        },
-        {
-          "name": "majorSwapThresholdTicks",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "setDefaultBaseFeeRate",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "adaptiveFeeTier",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "defaultBaseFeeRate",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "setDelegatedFeeAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "adaptiveFeeTier",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newDelegatedFeeAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setInitializePoolAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "adaptiveFeeTier",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newInitializePoolAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setPresetAdaptiveFeeConstants",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "adaptiveFeeTier",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "filterPeriod",
-          "type": "u16"
-        },
-        {
-          "name": "decayPeriod",
-          "type": "u16"
-        },
-        {
-          "name": "reductionFactor",
-          "type": "u16"
-        },
-        {
-          "name": "adaptiveFeeControlFactor",
-          "type": "u32"
-        },
-        {
-          "name": "maxVolatilityAccumulator",
-          "type": "u32"
-        },
-        {
-          "name": "tickGroupSize",
-          "type": "u16"
-        },
-        {
-          "name": "majorSwapThresholdTicks",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "initializePoolWithAdaptiveFee",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadgeA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadgeB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "initializePoolAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "adaptiveFeeTier",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "initialSqrtPrice",
-          "type": "u128"
-        },
-        {
-          "name": "tradeEnableTimestamp",
-          "type": {
-            "option": "u64"
-          }
-        }
-      ]
-    },
-    {
-      "name": "setFeeRateByDelegatedFeeAuthority",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "adaptiveFeeTier",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "delegatedFeeAuthority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "feeRate",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "collectFeesV2",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "option": {
-              "defined": "RemainingAccountsInfo"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "collectProtocolFeesV2",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "collectProtocolFeesAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenDestinationA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenDestinationB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "option": {
-              "defined": "RemainingAccountsInfo"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "collectRewardV2",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rewardOwnerAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "option": {
-              "defined": "RemainingAccountsInfo"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "decreaseLiquidityV2",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityAmount",
-          "type": "u128"
-        },
-        {
-          "name": "tokenMinA",
-          "type": "u64"
-        },
-        {
-          "name": "tokenMinB",
-          "type": "u64"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "option": {
-              "defined": "RemainingAccountsInfo"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "increaseLiquidityV2",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityAmount",
-          "type": "u128"
-        },
-        {
-          "name": "tokenMaxA",
-          "type": "u64"
-        },
-        {
-          "name": "tokenMaxB",
-          "type": "u64"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "option": {
-              "defined": "RemainingAccountsInfo"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "initializePoolV2",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadgeA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadgeB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "feeTier",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "tickSpacing",
-          "type": "u16"
-        },
-        {
-          "name": "initialSqrtPrice",
-          "type": "u128"
-        }
-      ]
-    },
-    {
-      "name": "initializeRewardV2",
-      "accounts": [
-        {
-          "name": "rewardAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rewardTokenBadge",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "rewardTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "setRewardEmissionsV2",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "rewardVault",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        },
-        {
-          "name": "emissionsPerSecondX64",
-          "type": "u128"
-        }
-      ]
-    },
-    {
-      "name": "swapV2",
-      "accounts": [
-        {
-          "name": "tokenProgramA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArray0",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArray1",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArray2",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "amount",
-          "type": "u64"
-        },
-        {
-          "name": "otherAmountThreshold",
-          "type": "u64"
-        },
-        {
-          "name": "sqrtPriceLimit",
-          "type": "u128"
-        },
-        {
-          "name": "amountSpecifiedIsInput",
-          "type": "bool"
-        },
-        {
-          "name": "aToB",
-          "type": "bool"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "option": {
-              "defined": "RemainingAccountsInfo"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "twoHopSwapV2",
-      "accounts": [
-        {
-          "name": "whirlpoolOne",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpoolTwo",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintInput",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintIntermediate",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintOutput",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramInput",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramIntermediate",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramOutput",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountInput",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultOneInput",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultOneIntermediate",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultTwoIntermediate",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultTwoOutput",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountOutput",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tickArrayOne0",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayOne1",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayOne2",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayTwo0",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayTwo1",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayTwo2",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracleOne",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracleTwo",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "amount",
-          "type": "u64"
-        },
-        {
-          "name": "otherAmountThreshold",
-          "type": "u64"
-        },
-        {
-          "name": "amountSpecifiedIsInput",
-          "type": "bool"
-        },
-        {
-          "name": "aToBOne",
-          "type": "bool"
-        },
-        {
-          "name": "aToBTwo",
-          "type": "bool"
-        },
-        {
-          "name": "sqrtPriceLimitOne",
-          "type": "u128"
-        },
-        {
-          "name": "sqrtPriceLimitTwo",
-          "type": "u128"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "option": {
-              "defined": "RemainingAccountsInfo"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "initializeConfigExtension",
-      "accounts": [
-        {
-          "name": "config",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "configExtension",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setConfigExtensionAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpoolsConfigExtension",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "configExtensionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newConfigExtensionAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setTokenBadgeAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpoolsConfigExtension",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "configExtensionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newTokenBadgeAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "initializeTokenBadge",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpoolsConfigExtension",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadgeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadge",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "deleteTokenBadge",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpoolsConfigExtension",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadgeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadge",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "receiver",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    }
-  ],
-  "accounts": [
-    {
-      "name": "AdaptiveFeeTier",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpoolsConfig",
-            "type": "publicKey"
-          },
-          {
-            "name": "feeTierIndex",
-            "type": "u16"
-          },
-          {
-            "name": "tickSpacing",
-            "type": "u16"
-          },
-          {
-            "name": "initializePoolAuthority",
-            "type": "publicKey"
-          },
-          {
-            "name": "delegatedFeeAuthority",
-            "type": "publicKey"
-          },
-          {
-            "name": "defaultBaseFeeRate",
-            "type": "u16"
-          },
-          {
-            "name": "filterPeriod",
-            "type": "u16"
-          },
-          {
-            "name": "decayPeriod",
-            "type": "u16"
-          },
-          {
-            "name": "reductionFactor",
-            "type": "u16"
-          },
-          {
-            "name": "adaptiveFeeControlFactor",
-            "type": "u32"
-          },
-          {
-            "name": "maxVolatilityAccumulator",
-            "type": "u32"
-          },
-          {
-            "name": "tickGroupSize",
-            "type": "u16"
-          },
-          {
-            "name": "majorSwapThresholdTicks",
-            "type": "u16"
-          }
-        ]
-      }
-    },
-    {
-      "name": "WhirlpoolsConfig",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "feeAuthority",
-            "type": "publicKey"
-          },
-          {
-            "name": "collectProtocolFeesAuthority",
-            "type": "publicKey"
-          },
-          {
-            "name": "rewardEmissionsSuperAuthority",
-            "type": "publicKey"
-          },
-          {
-            "name": "defaultProtocolFeeRate",
-            "type": "u16"
-          }
-        ]
-      }
-    },
-    {
-      "name": "WhirlpoolsConfigExtension",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpoolsConfig",
-            "type": "publicKey"
-          },
-          {
-            "name": "configExtensionAuthority",
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenBadgeAuthority",
-            "type": "publicKey"
-          }
-        ]
-      }
-    },
-    {
-      "name": "FeeTier",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpoolsConfig",
-            "type": "publicKey"
-          },
-          {
-            "name": "tickSpacing",
-            "type": "u16"
-          },
-          {
-            "name": "defaultFeeRate",
-            "type": "u16"
-          }
-        ]
-      }
-    },
-    {
-      "name": "LockConfig",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "position",
-            "type": "publicKey"
-          },
-          {
-            "name": "positionOwner",
-            "type": "publicKey"
-          },
-          {
-            "name": "whirlpool",
-            "type": "publicKey"
-          },
-          {
-            "name": "lockedTimestamp",
-            "type": "u64"
-          },
-          {
-            "name": "lockType",
-            "type": {
-              "defined": "LockTypeLabel"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "Oracle",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpool",
-            "type": "publicKey"
-          },
-          {
-            "name": "tradeEnableTimestamp",
-            "type": "u64"
-          },
-          {
-            "name": "adaptiveFeeConstants",
-            "type": {
-              "defined": "AdaptiveFeeConstants"
-            }
-          },
-          {
-            "name": "adaptiveFeeVariables",
-            "type": {
-              "defined": "AdaptiveFeeVariables"
-            }
-          },
-          {
-            "name": "reserved",
-            "type": {
-              "array": [
-                "u8",
-                128
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "Position",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpool",
-            "type": "publicKey"
-          },
-          {
-            "name": "positionMint",
-            "type": "publicKey"
-          },
-          {
-            "name": "liquidity",
-            "type": "u128"
-          },
-          {
-            "name": "tickLowerIndex",
-            "type": "i32"
-          },
-          {
-            "name": "tickUpperIndex",
-            "type": "i32"
-          },
-          {
-            "name": "feeGrowthCheckpointA",
-            "type": "u128"
-          },
-          {
-            "name": "feeOwedA",
-            "type": "u64"
-          },
-          {
-            "name": "feeGrowthCheckpointB",
-            "type": "u128"
-          },
-          {
-            "name": "feeOwedB",
-            "type": "u64"
-          },
-          {
-            "name": "rewardInfos",
-            "type": {
-              "array": [
+    "instructions": [
+        {
+            "name": "close_bundled_position",
+            "docs": [
+                "Close a bundled position in a Whirlpool.",
+                "",
+                "### Authority",
+                "- `position_bundle_authority` - authority that owns the token corresponding to this desired position bundle.",
+                "",
+                "### Parameters",
+                "- `bundle_index` - The bundle index that we'd like to close.",
+                "",
+                "#### Special Errors",
+                "- `InvalidBundleIndex` - If the provided bundle index is out of bounds.",
+                "- `ClosePositionNotEmpty` - The provided position account is not empty."
+            ],
+            "discriminator": [
+                41,
+                36,
+                216,
+                245,
+                27,
+                85,
+                103,
+                67
+            ],
+            "accounts": [
                 {
-                  "defined": "PositionRewardInfo"
+                    "name": "bundled_position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    98,
+                                    117,
+                                    110,
+                                    100,
+                                    108,
+                                    101,
+                                    100,
+                                    95,
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle.position_bundle_mint",
+                                "account": "PositionBundle"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "bundle_index"
+                            }
+                        ]
+                    }
                 },
-                3
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "PositionBundle",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "positionBundleMint",
-            "type": "publicKey"
-          },
-          {
-            "name": "positionBitmap",
-            "type": {
-              "array": [
-                "u8",
-                32
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "TickArray",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "startTickIndex",
-            "type": "i32"
-          },
-          {
-            "name": "ticks",
-            "type": {
-              "array": [
                 {
-                  "defined": "Tick"
+                    "name": "position_bundle",
+                    "writable": true
                 },
-                88
-              ]
-            }
-          },
-          {
-            "name": "whirlpool",
-            "type": "publicKey"
-          }
-        ]
-      }
-    },
-    {
-      "name": "TokenBadge",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpoolsConfig",
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenMint",
-            "type": "publicKey"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Whirlpool",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpoolsConfig",
-            "type": "publicKey"
-          },
-          {
-            "name": "whirlpoolBump",
-            "type": {
-              "array": [
-                "u8",
+                {
+                    "name": "position_bundle_token_account"
+                },
+                {
+                    "name": "position_bundle_authority",
+                    "signer": true
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "bundle_index",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "close_position",
+            "docs": [
+                "Close a position in a Whirlpool. Burns the position token in the owner's wallet.",
+                "",
+                "### Authority",
+                "- \"position_authority\" - The authority that owns the position token.",
+                "",
+                "#### Special Errors",
+                "- `ClosePositionNotEmpty` - The provided position account is not empty."
+            ],
+            "discriminator": [
+                123,
+                134,
+                81,
+                0,
+                49,
+                68,
+                98,
+                98
+            ],
+            "accounts": [
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                },
+                {
+                    "name": "position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "close_position_with_token_extensions",
+            "docs": [
+                "Close a position in a Whirlpool. Burns the position token in the owner's wallet.",
+                "Mint and TokenAccount are based on Token-2022. And Mint accout will be also closed.",
+                "",
+                "### Authority",
+                "- \"position_authority\" - The authority that owns the position token.",
+                "",
+                "#### Special Errors",
+                "- `ClosePositionNotEmpty` - The provided position account is not empty."
+            ],
+            "discriminator": [
+                1,
+                182,
+                135,
+                59,
+                155,
+                25,
+                99,
+                223
+            ],
+            "accounts": [
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                },
+                {
+                    "name": "position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "token_2022_program",
+                    "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "collect_fees",
+            "docs": [
+                "Collect fees accrued for this position.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position."
+            ],
+            "discriminator": [
+                164,
+                152,
+                207,
+                99,
+                30,
+                186,
+                19,
+                182
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "collect_fees_v2",
+            "docs": [
+                "Collect fees accrued for this position.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position."
+            ],
+            "discriminator": [
+                207,
+                117,
+                95,
+                191,
+                229,
+                180,
+                226,
+                15
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "collect_protocol_fees",
+            "docs": [
+                "Collect the protocol fees accrued in this Whirlpool",
+                "",
+                "### Authority",
+                "- `collect_protocol_fees_authority` - assigned authority in the WhirlpoolConfig that can collect protocol fees"
+            ],
+            "discriminator": [
+                22,
+                67,
+                23,
+                98,
+                150,
+                178,
+                70,
+                220
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "collect_protocol_fees_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_destination_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_destination_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "collect_protocol_fees_v2",
+            "docs": [
+                "Collect the protocol fees accrued in this Whirlpool",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `collect_protocol_fees_authority` - assigned authority in the WhirlpoolConfig that can collect protocol fees"
+            ],
+            "discriminator": [
+                103,
+                128,
+                222,
+                134,
+                114,
+                200,
+                22,
+                200
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "collect_protocol_fees_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_destination_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_destination_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "collect_reward",
+            "docs": [
+                "Collect rewards accrued for this position.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position."
+            ],
+            "discriminator": [
+                70,
+                5,
+                132,
+                87,
+                86,
+                235,
+                177,
+                34
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "reward_owner_account",
+                    "writable": true
+                },
+                {
+                    "name": "reward_vault",
+                    "writable": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "collect_reward_v2",
+            "docs": [
+                "Collect rewards accrued for this position.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position."
+            ],
+            "discriminator": [
+                177,
+                107,
+                37,
+                180,
+                160,
+                19,
+                49,
+                209
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "reward_owner_account",
+                    "writable": true
+                },
+                {
+                    "name": "reward_mint"
+                },
+                {
+                    "name": "reward_vault",
+                    "writable": true
+                },
+                {
+                    "name": "reward_token_program"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "decrease_liquidity",
+            "docs": [
+                "Withdraw liquidity from a position in the Whirlpool. This call also updates the position's accrued fees and rewards.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `liquidity_amount` - The total amount of Liquidity the user desires to withdraw.",
+                "- `token_min_a` - The minimum amount of tokenA the user is willing to withdraw.",
+                "- `token_min_b` - The minimum amount of tokenB the user is willing to withdraw.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMinSubceeded` - The required token to perform this operation subceeds the user defined amount."
+            ],
+            "discriminator": [
+                160,
+                38,
+                208,
+                111,
+                104,
+                91,
+                44,
                 1
-              ]
-            }
-          },
-          {
-            "name": "tickSpacing",
-            "type": "u16"
-          },
-          {
-            "name": "feeTierIndexSeed",
-            "type": {
-              "array": [
-                "u8",
-                2
-              ]
-            }
-          },
-          {
-            "name": "feeRate",
-            "type": "u16"
-          },
-          {
-            "name": "protocolFeeRate",
-            "type": "u16"
-          },
-          {
-            "name": "liquidity",
-            "type": "u128"
-          },
-          {
-            "name": "sqrtPrice",
-            "type": "u128"
-          },
-          {
-            "name": "tickCurrentIndex",
-            "type": "i32"
-          },
-          {
-            "name": "protocolFeeOwedA",
-            "type": "u64"
-          },
-          {
-            "name": "protocolFeeOwedB",
-            "type": "u64"
-          },
-          {
-            "name": "tokenMintA",
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenVaultA",
-            "type": "publicKey"
-          },
-          {
-            "name": "feeGrowthGlobalA",
-            "type": "u128"
-          },
-          {
-            "name": "tokenMintB",
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenVaultB",
-            "type": "publicKey"
-          },
-          {
-            "name": "feeGrowthGlobalB",
-            "type": "u128"
-          },
-          {
-            "name": "rewardLastUpdatedTimestamp",
-            "type": "u64"
-          },
-          {
-            "name": "rewardInfos",
-            "type": {
-              "array": [
+            ],
+            "accounts": [
                 {
-                  "defined": "WhirlpoolRewardInfo"
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
                 },
-                3
-              ]
-            }
-          }
-        ]
-      }
-    }
-  ],
-  "types": [
-    {
-      "name": "LockType",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Permanent"
-          }
-        ]
-      }
-    },
-    {
-      "name": "LockTypeLabel",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Permanent"
-          }
-        ]
-      }
-    },
-    {
-      "name": "AdaptiveFeeConstants",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "filterPeriod",
-            "type": "u16"
-          },
-          {
-            "name": "decayPeriod",
-            "type": "u16"
-          },
-          {
-            "name": "reductionFactor",
-            "type": "u16"
-          },
-          {
-            "name": "adaptiveFeeControlFactor",
-            "type": "u32"
-          },
-          {
-            "name": "maxVolatilityAccumulator",
-            "type": "u32"
-          },
-          {
-            "name": "tickGroupSize",
-            "type": "u16"
-          },
-          {
-            "name": "majorSwapThresholdTicks",
-            "type": "u16"
-          },
-          {
-            "name": "reserved",
-            "type": {
-              "array": [
-                "u8",
-                16
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "AdaptiveFeeVariables",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "lastReferenceUpdateTimestamp",
-            "type": "u64"
-          },
-          {
-            "name": "lastMajorSwapTimestamp",
-            "type": "u64"
-          },
-          {
-            "name": "volatilityReference",
-            "type": "u32"
-          },
-          {
-            "name": "tickGroupIndexReference",
-            "type": "i32"
-          },
-          {
-            "name": "volatilityAccumulator",
-            "type": "u32"
-          },
-          {
-            "name": "reserved",
-            "type": {
-              "array": [
-                "u8",
-                16
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "OpenPositionBumps",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "positionBump",
-            "type": "u8"
-          }
-        ]
-      }
-    },
-    {
-      "name": "OpenPositionWithMetadataBumps",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "positionBump",
-            "type": "u8"
-          },
-          {
-            "name": "metadataBump",
-            "type": "u8"
-          }
-        ]
-      }
-    },
-    {
-      "name": "PositionRewardInfo",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "growthInsideCheckpoint",
-            "type": "u128"
-          },
-          {
-            "name": "amountOwed",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Tick",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "initialized",
-            "type": "bool"
-          },
-          {
-            "name": "liquidityNet",
-            "type": "i128"
-          },
-          {
-            "name": "liquidityGross",
-            "type": "u128"
-          },
-          {
-            "name": "feeGrowthOutsideA",
-            "type": "u128"
-          },
-          {
-            "name": "feeGrowthOutsideB",
-            "type": "u128"
-          },
-          {
-            "name": "rewardGrowthsOutside",
-            "type": {
-              "array": [
-                "u128",
-                3
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "WhirlpoolBumps",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpoolBump",
-            "type": "u8"
-          }
-        ]
-      }
-    },
-    {
-      "name": "WhirlpoolRewardInfo",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "mint",
-            "type": "publicKey"
-          },
-          {
-            "name": "vault",
-            "type": "publicKey"
-          },
-          {
-            "name": "authority",
-            "type": "publicKey"
-          },
-          {
-            "name": "emissionsPerSecondX64",
-            "type": "u128"
-          },
-          {
-            "name": "growthGlobalX64",
-            "type": "u128"
-          }
-        ]
-      }
-    },
-    {
-      "name": "AccountsType",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "TransferHookA"
-          },
-          {
-            "name": "TransferHookB"
-          },
-          {
-            "name": "TransferHookReward"
-          },
-          {
-            "name": "TransferHookInput"
-          },
-          {
-            "name": "TransferHookIntermediate"
-          },
-          {
-            "name": "TransferHookOutput"
-          },
-          {
-            "name": "SupplementalTickArrays"
-          },
-          {
-            "name": "SupplementalTickArraysOne"
-          },
-          {
-            "name": "SupplementalTickArraysTwo"
-          }
-        ]
-      }
-    },
-    {
-      "name": "RemainingAccountsInfo",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "slices",
-            "type": {
-              "vec": {
-                "defined": "RemainingAccountsSlice"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "RemainingAccountsSlice",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "accountsType",
-            "type": {
-              "defined": "AccountsType"
-            }
-          },
-          {
-            "name": "length",
-            "type": "u8"
-          }
-        ]
-      }
-    }
-  ],
-  "events": [
-    {
-      "name": "LiquidityDecreased",
-      "fields": [
-        {
-          "name": "whirlpool",
-          "type": "publicKey",
-          "index": false
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "liquidity_amount",
+                    "type": "u128"
+                },
+                {
+                    "name": "token_min_a",
+                    "type": "u64"
+                },
+                {
+                    "name": "token_min_b",
+                    "type": "u64"
+                }
+            ]
         },
         {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
+            "name": "decrease_liquidity_v2",
+            "docs": [
+                "Withdraw liquidity from a position in the Whirlpool. This call also updates the position's accrued fees and rewards.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `liquidity_amount` - The total amount of Liquidity the user desires to withdraw.",
+                "- `token_min_a` - The minimum amount of tokenA the user is willing to withdraw.",
+                "- `token_min_b` - The minimum amount of tokenB the user is willing to withdraw.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMinSubceeded` - The required token to perform this operation subceeds the user defined amount."
+            ],
+            "discriminator": [
+                58,
+                127,
+                188,
+                62,
+                79,
+                82,
+                196,
+                96
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "liquidity_amount",
+                    "type": "u128"
+                },
+                {
+                    "name": "token_min_a",
+                    "type": "u64"
+                },
+                {
+                    "name": "token_min_b",
+                    "type": "u64"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
         },
         {
-          "name": "tickLowerIndex",
-          "type": "i32",
-          "index": false
+            "name": "delete_position_bundle",
+            "docs": [
+                "Delete a PositionBundle account. Burns the position bundle token in the owner's wallet.",
+                "",
+                "### Authority",
+                "- `position_bundle_owner` - The owner that owns the position bundle token.",
+                "",
+                "### Special Errors",
+                "- `PositionBundleNotDeletable` - The provided position bundle has open positions."
+            ],
+            "discriminator": [
+                100,
+                25,
+                99,
+                2,
+                217,
+                239,
+                124,
+                173
+            ],
+            "accounts": [
+                {
+                    "name": "position_bundle",
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_mint",
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_owner",
+                    "signer": true
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                }
+            ],
+            "args": []
         },
         {
-          "name": "tickUpperIndex",
-          "type": "i32",
-          "index": false
+            "name": "delete_token_badge",
+            "docs": [
+                "Delete a TokenBadge account.",
+                "",
+                "### Authority",
+                "- \"token_badge_authority\" - Set authority in the WhirlpoolConfigExtension",
+                "",
+                "### Special Errors",
+                "- `FeatureIsNotEnabled` - If the feature flag for token badges is not enabled."
+            ],
+            "discriminator": [
+                53,
+                146,
+                68,
+                8,
+                18,
+                117,
+                17,
+                185
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension",
+                        "token_badge"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension"
+                },
+                {
+                    "name": "token_badge_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_mint"
+                },
+                {
+                    "name": "token_badge",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                }
+            ],
+            "args": []
         },
         {
-          "name": "liquidity",
-          "type": "u128",
-          "index": false
+            "name": "idl_include",
+            "discriminator": [
+                223,
+                253,
+                121,
+                121,
+                60,
+                193,
+                129,
+                31
+            ],
+            "accounts": [
+                {
+                    "name": "tick_array"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": []
         },
         {
-          "name": "tokenAAmount",
-          "type": "u64",
-          "index": false
+            "name": "increase_liquidity",
+            "docs": [
+                "Add liquidity to a position in the Whirlpool. This call also updates the position's accrued fees and rewards.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `liquidity_amount` - The total amount of Liquidity the user is willing to deposit.",
+                "- `token_max_a` - The maximum amount of tokenA the user is willing to deposit.",
+                "- `token_max_b` - The maximum amount of tokenB the user is willing to deposit.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMaxExceeded` - The required token to perform this operation exceeds the user defined amount."
+            ],
+            "discriminator": [
+                46,
+                156,
+                243,
+                118,
+                13,
+                205,
+                251,
+                178
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "liquidity_amount",
+                    "type": "u128"
+                },
+                {
+                    "name": "token_max_a",
+                    "type": "u64"
+                },
+                {
+                    "name": "token_max_b",
+                    "type": "u64"
+                }
+            ]
         },
         {
-          "name": "tokenBAmount",
-          "type": "u64",
-          "index": false
+            "name": "increase_liquidity_by_token_amounts_v2",
+            "docs": [
+                "Add liquidity to a position by specifying token maxima, not liquidity.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "NOTE: This instruction is only implemented in Pinocchio, not Anchor.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `token_max_a` - The maximum amount of tokenA the user is willing to deposit.",
+                "- `token_max_b` - The maximum amount of tokenB the user is willing to deposit.",
+                "- `min_sqrt_price` - The minimum sqrt price allowed.",
+                "- `max_sqrt_price` - The maximum sqrt price allowed.",
+                "",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Computed liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Computed liquidity exceeds u128::max.",
+                "- `TokenMaxExceeded` - The required token to perform this operation exceeds the user defined amount."
+            ],
+            "discriminator": [
+                239,
+                251,
+                9,
+                124,
+                210,
+                198,
+                53,
+                43
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "method",
+                    "type": {
+                        "defined": {
+                            "name": "IncreaseLiquidityMethod"
+                        }
+                    }
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
         },
         {
-          "name": "tokenATransferFee",
-          "type": "u64",
-          "index": false
+            "name": "increase_liquidity_v2",
+            "docs": [
+                "Add liquidity to a position in the Whirlpool. This call also updates the position's accrued fees and rewards.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `liquidity_amount` - The total amount of Liquidity the user is willing to deposit.",
+                "- `token_max_a` - The maximum amount of tokenA the user is willing to deposit.",
+                "- `token_max_b` - The maximum amount of tokenB the user is willing to deposit.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMaxExceeded` - The required token to perform this operation exceeds the user defined amount."
+            ],
+            "discriminator": [
+                133,
+                29,
+                89,
+                223,
+                69,
+                238,
+                176,
+                10
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "liquidity_amount",
+                    "type": "u128"
+                },
+                {
+                    "name": "token_max_a",
+                    "type": "u64"
+                },
+                {
+                    "name": "token_max_b",
+                    "type": "u64"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
         },
         {
-          "name": "tokenBTransferFee",
-          "type": "u64",
-          "index": false
+            "name": "initialize_adaptive_fee_tier",
+            "docs": [
+                "Initializes an adaptive_fee_tier account usable by Whirlpools in a WhirlpoolConfig space.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `fee_tier_index` - The index of the fee-tier that this adaptive fee tier will be initialized.",
+                "- `tick_spacing` - The tick-spacing that this fee-tier suggests the default_fee_rate for.",
+                "- `initialize_pool_authority` - The authority that can initialize pools with this adaptive fee-tier.",
+                "- `delegated_fee_authority` - The authority that can set the base fee rate for pools using this adaptive fee-tier.",
+                "- `default_fee_rate` - The default fee rate that a pool will use if the pool uses this",
+                "fee tier during initialization.",
+                "- `filter_period` - Period determine high frequency trading time window. (seconds)",
+                "- `decay_period` - Period determine when the adaptive fee start decrease. (seconds)",
+                "- `reduction_factor` - Adaptive fee rate decrement rate.",
+                "- `adaptive_fee_control_factor` - Adaptive fee control factor.",
+                "- `max_volatility_accumulator` - Max volatility accumulator.",
+                "- `tick_group_size` - Tick group size to define tick group index.",
+                "- `major_swap_threshold_ticks` - Major swap threshold ticks to define major swap.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickSpacing` - If the provided tick_spacing is 0.",
+                "- `InvalidFeeTierIndex` - If the provided fee_tier_index is same to tick_spacing.",
+                "- `FeeRateMaxExceeded` - If the provided default_fee_rate exceeds MAX_FEE_RATE.",
+                "- `InvalidAdaptiveFeeConstants` - If the provided adaptive fee constants are invalid."
+            ],
+            "discriminator": [
+                77,
+                99,
+                208,
+                200,
+                141,
+                123,
+                117,
+                48
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config"
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    102,
+                                    101,
+                                    101,
+                                    95,
+                                    116,
+                                    105,
+                                    101,
+                                    114
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "fee_tier_index"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "fee_tier_index",
+                    "type": "u16"
+                },
+                {
+                    "name": "tick_spacing",
+                    "type": "u16"
+                },
+                {
+                    "name": "initialize_pool_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "delegated_fee_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "default_base_fee_rate",
+                    "type": "u16"
+                },
+                {
+                    "name": "filter_period",
+                    "type": "u16"
+                },
+                {
+                    "name": "decay_period",
+                    "type": "u16"
+                },
+                {
+                    "name": "reduction_factor",
+                    "type": "u16"
+                },
+                {
+                    "name": "adaptive_fee_control_factor",
+                    "type": "u32"
+                },
+                {
+                    "name": "max_volatility_accumulator",
+                    "type": "u32"
+                },
+                {
+                    "name": "tick_group_size",
+                    "type": "u16"
+                },
+                {
+                    "name": "major_swap_threshold_ticks",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "initialize_config",
+            "docs": [
+                "Initializes a WhirlpoolsConfig account that hosts info & authorities",
+                "required to govern a set of Whirlpools.",
+                "",
+                "### Authority",
+                "- \"authority\" - Set authority that is one of ADMINS.",
+                "",
+                "### Parameters",
+                "- `fee_authority` - Authority authorized to initialize fee-tiers and set customs fees.",
+                "- `collect_protocol_fees_authority` - Authority authorized to collect protocol fees.",
+                "- `reward_emissions_super_authority` - Authority authorized to set reward authorities in pools."
+            ],
+            "discriminator": [
+                208,
+                127,
+                21,
+                1,
+                194,
+                190,
+                196,
+                70
+            ],
+            "accounts": [
+                {
+                    "name": "config",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "fee_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "collect_protocol_fees_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "reward_emissions_super_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "default_protocol_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "initialize_config_extension",
+            "docs": [
+                "Initializes a WhirlpoolConfigExtension account that hosts info & authorities.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                55,
+                9,
+                53,
+                9,
+                114,
+                57,
+                209,
+                52
+            ],
+            "accounts": [
+                {
+                    "name": "config"
+                },
+                {
+                    "name": "config_extension",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    99,
+                                    111,
+                                    110,
+                                    102,
+                                    105,
+                                    103,
+                                    95,
+                                    101,
+                                    120,
+                                    116,
+                                    101,
+                                    110,
+                                    115,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "config"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "initialize_dynamic_tick_array",
+            "docs": [
+                "Initialize a variable-length tick array for a Whirlpool.",
+                "",
+                "### Parameters",
+                "- `start_tick_index` - The starting tick index for this tick-array.",
+                "Has to be a multiple of TickArray size & the tick spacing of this pool.",
+                "- `idempotent` - If true, the instruction will not fail if the tick array already exists.",
+                "Note: The idempotent option exits successfully if a FixedTickArray is present as well as a DynamicTickArray.",
+                "",
+                "#### Special Errors",
+                "- `InvalidStartTick` - if the provided start tick is out of bounds or is not a multiple of",
+                "TICK_ARRAY_SIZE * tick spacing."
+            ],
+            "discriminator": [
+                41,
+                33,
+                165,
+                200,
+                120,
+                231,
+                142,
+                50
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "tick_array",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    105,
+                                    99,
+                                    107,
+                                    95,
+                                    97,
+                                    114,
+                                    114,
+                                    97,
+                                    121
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "start_tick_index"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "start_tick_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "idempotent",
+                    "type": "bool"
+                }
+            ]
+        },
+        {
+            "name": "initialize_fee_tier",
+            "docs": [
+                "Initializes a fee_tier account usable by Whirlpools in a WhirlpoolConfig space.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `tick_spacing` - The tick-spacing that this fee-tier suggests the default_fee_rate for.",
+                "- `default_fee_rate` - The default fee rate that a pool will use if the pool uses this",
+                "fee tier during initialization.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickSpacing` - If the provided tick_spacing is 0.",
+                "- `FeeRateMaxExceeded` - If the provided default_fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                183,
+                74,
+                156,
+                160,
+                112,
+                2,
+                42,
+                30
+            ],
+            "accounts": [
+                {
+                    "name": "config"
+                },
+                {
+                    "name": "fee_tier",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    102,
+                                    101,
+                                    101,
+                                    95,
+                                    116,
+                                    105,
+                                    101,
+                                    114
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "config"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "tick_spacing"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "tick_spacing",
+                    "type": "u16"
+                },
+                {
+                    "name": "default_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "initialize_pool",
+            "docs": [
+                "Initializes a Whirlpool account.",
+                "Fee rate is set to the default values on the config and supplied fee_tier.",
+                "",
+                "### Parameters",
+                "- `bumps` - The bump value when deriving the PDA of the Whirlpool address.",
+                "- `tick_spacing` - The desired tick spacing for this pool.",
+                "- `initial_sqrt_price` - The desired initial sqrt-price for this pool",
+                "",
+                "#### Special Errors",
+                "`InvalidTokenMintOrder` - The order of mints have to be ordered by",
+                "`SqrtPriceOutOfBounds` - provided initial_sqrt_price is not between 2^-64 to 2^64",
+                ""
+            ],
+            "discriminator": [
+                95,
+                180,
+                10,
+                172,
+                84,
+                174,
+                232,
+                40
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "fee_tier"
+                    ]
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    119,
+                                    104,
+                                    105,
+                                    114,
+                                    108,
+                                    112,
+                                    111,
+                                    111,
+                                    108
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "tick_spacing"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "fee_tier"
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "bumps",
+                    "type": {
+                        "defined": {
+                            "name": "WhirlpoolBumps"
+                        }
+                    }
+                },
+                {
+                    "name": "tick_spacing",
+                    "type": "u16"
+                },
+                {
+                    "name": "initial_sqrt_price",
+                    "type": "u128"
+                }
+            ]
+        },
+        {
+            "name": "initialize_pool_v2",
+            "docs": [
+                "Initializes a Whirlpool account.",
+                "This instruction works with both Token and Token-2022.",
+                "Fee rate is set to the default values on the config and supplied fee_tier.",
+                "",
+                "### Parameters",
+                "- `bumps` - The bump value when deriving the PDA of the Whirlpool address.",
+                "- `tick_spacing` - The desired tick spacing for this pool.",
+                "- `initial_sqrt_price` - The desired initial sqrt-price for this pool",
+                "",
+                "#### Special Errors",
+                "`InvalidTokenMintOrder` - The order of mints have to be ordered by",
+                "`SqrtPriceOutOfBounds` - provided initial_sqrt_price is not between 2^-64 to 2^64",
+                ""
+            ],
+            "discriminator": [
+                207,
+                45,
+                87,
+                242,
+                27,
+                63,
+                204,
+                67
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "fee_tier"
+                    ]
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_badge_a",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "token_badge_b",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    119,
+                                    104,
+                                    105,
+                                    114,
+                                    108,
+                                    112,
+                                    111,
+                                    111,
+                                    108
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "tick_spacing"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "fee_tier"
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "tick_spacing",
+                    "type": "u16"
+                },
+                {
+                    "name": "initial_sqrt_price",
+                    "type": "u128"
+                }
+            ]
+        },
+        {
+            "name": "initialize_pool_with_adaptive_fee",
+            "docs": [
+                "Initializes a Whirlpool account and Oracle account with adaptive fee.",
+                "",
+                "### Parameters",
+                "- `initial_sqrt_price` - The desired initial sqrt-price for this pool",
+                "- `trade_enable_timestamp` - The timestamp when trading is enabled for this pool (within 72 hours)",
+                "",
+                "#### Special Errors",
+                "`InvalidTokenMintOrder` - The order of mints have to be ordered by",
+                "`SqrtPriceOutOfBounds` - provided initial_sqrt_price is not between 2^-64 to 2^64",
+                "`InvalidTradeEnableTimestamp` - provided trade_enable_timestamp is not within 72 hours or the adaptive fee-tier is permission-less",
+                "`UnsupportedTokenMint` - The provided token mint is not supported by the program (e.g. it has risky token extensions)",
+                ""
+            ],
+            "discriminator": [
+                143,
+                94,
+                96,
+                76,
+                172,
+                124,
+                119,
+                199
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_badge_a",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "token_badge_b",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "initialize_pool_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    119,
+                                    104,
+                                    105,
+                                    114,
+                                    108,
+                                    112,
+                                    111,
+                                    111,
+                                    108
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "adaptive_fee_tier.fee_tier_index",
+                                "account": "AdaptiveFeeTier"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "oracle",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "adaptive_fee_tier"
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "initial_sqrt_price",
+                    "type": "u128"
+                },
+                {
+                    "name": "trade_enable_timestamp",
+                    "type": {
+                        "option": "u64"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "initialize_position_bundle",
+            "docs": [
+                "Initializes a PositionBundle account that bundles several positions.",
+                "A unique token will be minted to represent the position bundle in the users wallet."
+            ],
+            "discriminator": [
+                117,
+                45,
+                241,
+                149,
+                24,
+                18,
+                194,
+                65
+            ],
+            "accounts": [
+                {
+                    "name": "position_bundle",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110,
+                                    95,
+                                    98,
+                                    117,
+                                    110,
+                                    100,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_bundle_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_bundle_token_account",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_owner"
+                            },
+                            {
+                                "kind": "const",
+                                "value": [
+                                    6,
+                                    221,
+                                    246,
+                                    225,
+                                    215,
+                                    101,
+                                    161,
+                                    147,
+                                    217,
+                                    203,
+                                    225,
+                                    70,
+                                    206,
+                                    235,
+                                    121,
+                                    172,
+                                    28,
+                                    180,
+                                    133,
+                                    237,
+                                    95,
+                                    91,
+                                    55,
+                                    145,
+                                    58,
+                                    140,
+                                    245,
+                                    133,
+                                    126,
+                                    255,
+                                    0,
+                                    169
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_mint"
+                            }
+                        ],
+                        "program": {
+                            "kind": "const",
+                            "value": [
+                                140,
+                                151,
+                                37,
+                                143,
+                                78,
+                                36,
+                                137,
+                                241,
+                                187,
+                                61,
+                                16,
+                                41,
+                                20,
+                                142,
+                                13,
+                                131,
+                                11,
+                                90,
+                                19,
+                                153,
+                                218,
+                                255,
+                                16,
+                                132,
+                                4,
+                                142,
+                                123,
+                                216,
+                                219,
+                                233,
+                                248,
+                                89
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "position_bundle_owner"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "initialize_position_bundle_with_metadata",
+            "docs": [
+                "Initializes a PositionBundle account that bundles several positions.",
+                "A unique token will be minted to represent the position bundle in the users wallet.",
+                "Additional Metaplex metadata is appended to identify the token."
+            ],
+            "discriminator": [
+                93,
+                124,
+                16,
+                179,
+                249,
+                131,
+                115,
+                245
+            ],
+            "accounts": [
+                {
+                    "name": "position_bundle",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110,
+                                    95,
+                                    98,
+                                    117,
+                                    110,
+                                    100,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_bundle_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_bundle_metadata",
+                    "docs": [
+                        "https://github.com/metaplex-foundation/metaplex-program-library/blob/773a574c4b34e5b9f248a81306ec24db064e255f/token-metadata/program/src/utils/metadata.rs#L100"
+                    ],
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_token_account",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_owner"
+                            },
+                            {
+                                "kind": "const",
+                                "value": [
+                                    6,
+                                    221,
+                                    246,
+                                    225,
+                                    215,
+                                    101,
+                                    161,
+                                    147,
+                                    217,
+                                    203,
+                                    225,
+                                    70,
+                                    206,
+                                    235,
+                                    121,
+                                    172,
+                                    28,
+                                    180,
+                                    133,
+                                    237,
+                                    95,
+                                    91,
+                                    55,
+                                    145,
+                                    58,
+                                    140,
+                                    245,
+                                    133,
+                                    126,
+                                    255,
+                                    0,
+                                    169
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_mint"
+                            }
+                        ],
+                        "program": {
+                            "kind": "const",
+                            "value": [
+                                140,
+                                151,
+                                37,
+                                143,
+                                78,
+                                36,
+                                137,
+                                241,
+                                187,
+                                61,
+                                16,
+                                41,
+                                20,
+                                142,
+                                13,
+                                131,
+                                11,
+                                90,
+                                19,
+                                153,
+                                218,
+                                255,
+                                16,
+                                132,
+                                4,
+                                142,
+                                123,
+                                216,
+                                219,
+                                233,
+                                248,
+                                89
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "position_bundle_owner"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "metadata_update_auth",
+                    "address": "3axbTs2z5GBy6usVbNVoqEgZMng3vZvMnAoX29BFfwhr"
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                },
+                {
+                    "name": "metadata_program",
+                    "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "initialize_reward",
+            "docs": [
+                "Initialize reward for a Whirlpool. A pool can only support up to a set number of rewards.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - assigned authority by the reward_super_authority for the specified",
+                "reward-index in this Whirlpool",
+                "",
+                "### Parameters",
+                "- `reward_index` - The reward index that we'd like to initialize. (0 <= index <= NUM_REWARDS)",
+                "",
+                "#### Special Errors",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                95,
+                135,
+                192,
+                196,
+                242,
+                129,
+                230,
+                68
+            ],
+            "accounts": [
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_mint"
+                },
+                {
+                    "name": "reward_vault",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "initialize_reward_v2",
+            "docs": [
+                "Initialize reward for a Whirlpool. A pool can only support up to a set number of rewards.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - assigned authority by the reward_super_authority for the specified",
+                "reward-index in this Whirlpool",
+                "",
+                "### Parameters",
+                "- `reward_index` - The reward index that we'd like to initialize. (0 <= index <= NUM_REWARDS)",
+                "",
+                "#### Special Errors",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                91,
+                1,
+                77,
+                50,
+                235,
+                229,
+                133,
+                49
+            ],
+            "accounts": [
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_mint"
+                },
+                {
+                    "name": "reward_token_badge",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool.whirlpools_config",
+                                "account": "Whirlpool"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "reward_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "reward_vault",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "reward_token_program"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "initialize_tick_array",
+            "docs": [
+                "Initializes a fixed-length tick_array account to represent a tick-range in a Whirlpool.",
+                "",
+                "### Parameters",
+                "- `start_tick_index` - The starting tick index for this tick-array.",
+                "Has to be a multiple of TickArray size & the tick spacing of this pool.",
+                "",
+                "#### Special Errors",
+                "- `InvalidStartTick` - if the provided start tick is out of bounds or is not a multiple of",
+                "TICK_ARRAY_SIZE * tick spacing."
+            ],
+            "discriminator": [
+                11,
+                188,
+                193,
+                214,
+                141,
+                91,
+                149,
+                184
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "tick_array",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    105,
+                                    99,
+                                    107,
+                                    95,
+                                    97,
+                                    114,
+                                    114,
+                                    97,
+                                    121
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "start_tick_index"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "start_tick_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "initialize_token_badge",
+            "docs": [
+                "Initialize a TokenBadge account.",
+                "",
+                "### Authority",
+                "- \"token_badge_authority\" - Set authority in the WhirlpoolConfigExtension",
+                "",
+                "### Special Errors",
+                "- `FeatureIsNotEnabled` - If the feature flag for token badges is not enabled."
+            ],
+            "discriminator": [
+                253,
+                77,
+                205,
+                95,
+                27,
+                224,
+                89,
+                223
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension"
+                },
+                {
+                    "name": "token_badge_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_mint"
+                },
+                {
+                    "name": "token_badge",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "lock_position",
+            "docs": [
+                "Lock the position to prevent any liquidity changes.",
+                "",
+                "### Authority",
+                "- `position_authority` - The authority that owns the position token.",
+                "",
+                "#### Special Errors",
+                "- `PositionAlreadyLocked` - The provided position is already locked.",
+                "- `PositionNotLockable` - The provided position is not lockable (e.g. An empty position)."
+            ],
+            "discriminator": [
+                227,
+                62,
+                2,
+                252,
+                247,
+                10,
+                171,
+                185
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint"
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "lock_config",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    108,
+                                    111,
+                                    99,
+                                    107,
+                                    95,
+                                    99,
+                                    111,
+                                    110,
+                                    102,
+                                    105,
+                                    103
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_2022_program",
+                    "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "lock_type",
+                    "type": {
+                        "defined": {
+                            "name": "LockType"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "migrate_repurpose_reward_authority_space",
+            "docs": [
+                "Migration instruction to repurpose the reward authority space in the Whirlpool.",
+                "TODO: This instruction should be removed once all pools have been migrated."
+            ],
+            "discriminator": [
+                214,
+                161,
+                248,
+                79,
+                152,
+                98,
+                172,
+                231
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "open_bundled_position",
+            "docs": [
+                "Open a bundled position in a Whirlpool. No new tokens are issued",
+                "because the owner of the position bundle becomes the owner of the position.",
+                "The position will start off with 0 liquidity.",
+                "",
+                "### Authority",
+                "- `position_bundle_authority` - authority that owns the token corresponding to this desired position bundle.",
+                "",
+                "### Parameters",
+                "- `bundle_index` - The bundle index that we'd like to open.",
+                "- `tick_lower_index` - The tick specifying the lower end of the position range.",
+                "- `tick_upper_index` - The tick specifying the upper end of the position range.",
+                "",
+                "#### Special Errors",
+                "- `InvalidBundleIndex` - If the provided bundle index is out of bounds.",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool."
+            ],
+            "discriminator": [
+                169,
+                113,
+                126,
+                171,
+                213,
+                172,
+                212,
+                49
+            ],
+            "accounts": [
+                {
+                    "name": "bundled_position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    98,
+                                    117,
+                                    110,
+                                    100,
+                                    108,
+                                    101,
+                                    100,
+                                    95,
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle.position_bundle_mint",
+                                "account": "PositionBundle"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "bundle_index"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_bundle",
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_token_account"
+                },
+                {
+                    "name": "position_bundle_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "bundle_index",
+                    "type": "u16"
+                },
+                {
+                    "name": "tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "tick_upper_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "open_position",
+            "docs": [
+                "Open a position in a Whirlpool. A unique token will be minted to represent the position",
+                "in the users wallet. The position will start off with 0 liquidity.",
+                "",
+                "### Parameters",
+                "- `tick_lower_index` - The tick specifying the lower end of the position range.",
+                "- `tick_upper_index` - The tick specifying the upper end of the position range.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool."
+            ],
+            "discriminator": [
+                135,
+                128,
+                47,
+                77,
+                15,
+                152,
+                240,
+                49
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "owner"
+                },
+                {
+                    "name": "position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "account",
+                                "path": "owner"
+                            },
+                            {
+                                "kind": "const",
+                                "value": [
+                                    6,
+                                    221,
+                                    246,
+                                    225,
+                                    215,
+                                    101,
+                                    161,
+                                    147,
+                                    217,
+                                    203,
+                                    225,
+                                    70,
+                                    206,
+                                    235,
+                                    121,
+                                    172,
+                                    28,
+                                    180,
+                                    133,
+                                    237,
+                                    95,
+                                    91,
+                                    55,
+                                    145,
+                                    58,
+                                    140,
+                                    245,
+                                    133,
+                                    126,
+                                    255,
+                                    0,
+                                    169
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ],
+                        "program": {
+                            "kind": "const",
+                            "value": [
+                                140,
+                                151,
+                                37,
+                                143,
+                                78,
+                                36,
+                                137,
+                                241,
+                                187,
+                                61,
+                                16,
+                                41,
+                                20,
+                                142,
+                                13,
+                                131,
+                                11,
+                                90,
+                                19,
+                                153,
+                                218,
+                                255,
+                                16,
+                                132,
+                                4,
+                                142,
+                                123,
+                                216,
+                                219,
+                                233,
+                                248,
+                                89
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                }
+            ],
+            "args": [
+                {
+                    "name": "bumps",
+                    "type": {
+                        "defined": {
+                            "name": "OpenPositionBumps"
+                        }
+                    }
+                },
+                {
+                    "name": "tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "tick_upper_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "open_position_with_metadata",
+            "docs": [
+                "Open a position in a Whirlpool. A unique token will be minted to represent the position",
+                "in the users wallet. Additional Metaplex metadata is appended to identify the token.",
+                "The position will start off with 0 liquidity.",
+                "",
+                "### Parameters",
+                "- `tick_lower_index` - The tick specifying the lower end of the position range.",
+                "- `tick_upper_index` - The tick specifying the upper end of the position range.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool."
+            ],
+            "discriminator": [
+                242,
+                29,
+                134,
+                48,
+                58,
+                110,
+                14,
+                60
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "owner"
+                },
+                {
+                    "name": "position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_metadata_account",
+                    "docs": [
+                        "https://github.com/metaplex-foundation/mpl-token-metadata/blob/master/programs/token-metadata/program/src/utils/metadata.rs#L78"
+                    ],
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "account",
+                                "path": "owner"
+                            },
+                            {
+                                "kind": "const",
+                                "value": [
+                                    6,
+                                    221,
+                                    246,
+                                    225,
+                                    215,
+                                    101,
+                                    161,
+                                    147,
+                                    217,
+                                    203,
+                                    225,
+                                    70,
+                                    206,
+                                    235,
+                                    121,
+                                    172,
+                                    28,
+                                    180,
+                                    133,
+                                    237,
+                                    95,
+                                    91,
+                                    55,
+                                    145,
+                                    58,
+                                    140,
+                                    245,
+                                    133,
+                                    126,
+                                    255,
+                                    0,
+                                    169
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ],
+                        "program": {
+                            "kind": "const",
+                            "value": [
+                                140,
+                                151,
+                                37,
+                                143,
+                                78,
+                                36,
+                                137,
+                                241,
+                                187,
+                                61,
+                                16,
+                                41,
+                                20,
+                                142,
+                                13,
+                                131,
+                                11,
+                                90,
+                                19,
+                                153,
+                                218,
+                                255,
+                                16,
+                                132,
+                                4,
+                                142,
+                                123,
+                                216,
+                                219,
+                                233,
+                                248,
+                                89
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                },
+                {
+                    "name": "metadata_program",
+                    "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+                },
+                {
+                    "name": "metadata_update_auth",
+                    "address": "3axbTs2z5GBy6usVbNVoqEgZMng3vZvMnAoX29BFfwhr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "bumps",
+                    "type": {
+                        "defined": {
+                            "name": "OpenPositionWithMetadataBumps"
+                        }
+                    }
+                },
+                {
+                    "name": "tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "tick_upper_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "open_position_with_token_extensions",
+            "docs": [
+                "Open a position in a Whirlpool. A unique token will be minted to represent the position",
+                "in the users wallet. Additional TokenMetadata extension is initialized to identify the token.",
+                "Mint and TokenAccount are based on Token-2022.",
+                "The position will start off with 0 liquidity.",
+                "",
+                "### Parameters",
+                "- `tick_lower_index` - The tick specifying the lower end of the position range.",
+                "- `tick_upper_index` - The tick specifying the upper end of the position range.",
+                "- `with_token_metadata_extension` - If true, the token metadata extension will be initialized.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool."
+            ],
+            "discriminator": [
+                212,
+                47,
+                95,
+                92,
+                114,
+                102,
+                131,
+                250
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "owner"
+                },
+                {
+                    "name": "position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "token_2022_program",
+                    "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                },
+                {
+                    "name": "metadata_update_auth",
+                    "address": "3axbTs2z5GBy6usVbNVoqEgZMng3vZvMnAoX29BFfwhr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "tick_upper_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "with_token_metadata_extension",
+                    "type": "bool"
+                }
+            ]
+        },
+        {
+            "name": "reposition_liquidity_v2",
+            "docs": [
+                "An atomic instruction that repositions liquidity for a position through the following steps:",
+                "- Withdraws liquidity from the current position range",
+                "- Resets the position to a new tick range",
+                "- Adds liquidity to the new position range",
+                "- Restores fees and rewards",
+                "",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `new_tick_lower_index` - The new tick index for the lower end of the position range.",
+                "- `new_tick_upper_index` - The new tick index for the upper end of the position range.",
+                "- `new_liquidity_amount` - The total amount of Liquidity the user is willing to deposit.",
+                "- `existing_range_token_min_a` - The minimum amount of tokenA the user is willing to withdraw from the existing range.",
+                "- `existing_range_token_min_b` - The minimum amount of tokenB the user is willing to withdraw from the existing range.",
+                "- `new_range_token_max_a` - The maximum amount of tokenA the user is willing to deposit into the new range.",
+                "- `new_range_token_max_b` - The maximum amount of tokenB the user is willing to deposit into the new range.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMaxExceeded` - The required token to perform this operation exceeds the user defined amount.",
+                "- `TokenMinSubceeded` - The required token to perform this operation subceeds the user defined amount.",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool.",
+                "- `SameTickRangeNotAllowed` - The provided tick range is the same as the current tick range."
+            ],
+            "discriminator": [
+                191,
+                169,
+                224,
+                11,
+                131,
+                19,
+                158,
+                253
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "existing_tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "existing_tick_array_upper",
+                    "writable": true
+                },
+                {
+                    "name": "new_tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "new_tick_array_upper",
+                    "writable": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "new_tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "new_tick_upper_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "method",
+                    "type": {
+                        "defined": {
+                            "name": "RepositionLiquidityMethod"
+                        }
+                    }
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "reset_position_range",
+            "docs": [
+                "Reset the position range to a new range.",
+                "",
+                "### Authority",
+                "- `position_authority` - The authority that owns the position token.",
+                "",
+                "### Parameters",
+                "- `new_tick_lower_index` - The new tick specifying the lower end of the position range.",
+                "- `new_tick_upper_index` - The new tick specifying the upper end of the position range.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool.",
+                "- `ClosePositionNotEmpty` - The provided position account is not empty.",
+                "- `SameTickRangeNotAllowed` - The provided tick range is the same as the current tick range."
+            ],
+            "discriminator": [
+                164,
+                123,
+                180,
+                141,
+                194,
+                100,
+                160,
+                175
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "new_tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "new_tick_upper_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "set_adaptive_fee_constants",
+            "docs": [
+                "Sets specific adaptive fee constants for a pool. Only the provided constants will be updated,",
+                "others remain unchanged. Caller should avoid invoking this instruction when a pool's adaptive",
+                "fee is high to prevent LP revenue loss",
+                "",
+                "### Authority",
+                "- `fee_authority` - Set authority in the WhirlpoolsConfig",
+                "",
+                "### Parameters",
+                "All parameters are optional. Only provided values will be updated.",
+                "- `filter_period` - Period determine high frequency trading time window. (seconds)",
+                "- `decay_period` - Period determine when the adaptive fee start decrease. (seconds)",
+                "- `reduction_factor` - Adaptive fee rate decrement rate.",
+                "- `adaptive_fee_control_factor` - Adaptive fee control factor.",
+                "- `max_volatility_accumulator` - Max volatility accumulator.",
+                "- `tick_group_size` - Tick group size to define tick group index.",
+                "- `major_swap_threshold_ticks` - Major swap threshold ticks to define major swap.",
+                "",
+                "#### Special Errors",
+                "- `InvalidAdaptiveFeeConstants` - If the resulting constants are invalid for the pool's tick_spacing.",
+                "- `AdaptiveFeeConstantsUnchanged` - If the provided adaptive fee constants are unchanged from the existing constants."
+            ],
+            "discriminator": [
+                133,
+                158,
+                212,
+                189,
+                237,
+                12,
+                73,
+                39
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "oracle"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "oracle",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "filter_period",
+                    "type": {
+                        "option": "u16"
+                    }
+                },
+                {
+                    "name": "decay_period",
+                    "type": {
+                        "option": "u16"
+                    }
+                },
+                {
+                    "name": "reduction_factor",
+                    "type": {
+                        "option": "u16"
+                    }
+                },
+                {
+                    "name": "adaptive_fee_control_factor",
+                    "type": {
+                        "option": "u32"
+                    }
+                },
+                {
+                    "name": "max_volatility_accumulator",
+                    "type": {
+                        "option": "u32"
+                    }
+                },
+                {
+                    "name": "tick_group_size",
+                    "type": {
+                        "option": "u16"
+                    }
+                },
+                {
+                    "name": "major_swap_threshold_ticks",
+                    "type": {
+                        "option": "u16"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "set_collect_protocol_fees_authority",
+            "docs": [
+                "Sets the fee authority to collect protocol fees for a WhirlpoolConfig.",
+                "Only the current collect protocol fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can collect protocol fees in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                34,
+                150,
+                93,
+                244,
+                139,
+                225,
+                233,
+                67
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "collect_protocol_fees_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_collect_protocol_fees_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_config_extension_authority",
+            "docs": [
+                "Sets the config extension authority for a WhirlpoolsConfigExtension.",
+                "Only the current config extension authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"config_extension_authority\" - Set authority in the WhirlpoolConfigExtension"
+            ],
+            "discriminator": [
+                44,
+                94,
+                241,
+                116,
+                24,
+                188,
+                60,
+                143
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension",
+                    "writable": true
+                },
+                {
+                    "name": "config_extension_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_config_extension_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_config_feature_flag",
+            "docs": [
+                "Sets the feature flag for a WhirlpoolConfig.",
+                "",
+                "### Authority",
+                "- \"authority\" - Set authority that is one of ADMINS.",
+                "",
+                "### Parameters",
+                "- `feature_flag` - The feature flag that the WhirlpoolConfig will use."
+            ],
+            "discriminator": [
+                71,
+                173,
+                228,
+                18,
+                67,
+                247,
+                210,
+                57
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "feature_flag",
+                    "type": {
+                        "defined": {
+                            "name": "ConfigFeatureFlag"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "set_default_base_fee_rate",
+            "docs": [
+                "Set the default_base_fee_rate for an AdaptiveFeeTier",
+                "Only the current fee authority in WhirlpoolsConfig has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `default_base_fee_rate` - The default base fee rate that a pool will use if the pool uses this",
+                "adaptive fee-tier during initialization.",
+                "",
+                "#### Special Errors",
+                "- `FeeRateMaxExceeded` - If the provided default_fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                229,
+                66,
+                84,
+                251,
+                164,
+                134,
+                183,
+                7
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "default_base_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_default_fee_rate",
+            "docs": [
+                "Set the default_fee_rate for a FeeTier",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `default_fee_rate` - The default fee rate that a pool will use if the pool uses this",
+                "fee tier during initialization.",
+                "",
+                "#### Special Errors",
+                "- `FeeRateMaxExceeded` - If the provided default_fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                118,
+                215,
+                214,
+                157,
+                182,
+                229,
+                208,
+                228
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "fee_tier"
+                    ]
+                },
+                {
+                    "name": "fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "default_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_default_protocol_fee_rate",
+            "docs": [
+                "Sets the default protocol fee rate for a WhirlpoolConfig",
+                "Protocol fee rate is represented as a basis point.",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can modify pool fees in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `default_protocol_fee_rate` - Rate that is referenced during the initialization of a Whirlpool using this config.",
+                "",
+                "#### Special Errors",
+                "- `ProtocolFeeRateMaxExceeded` - If the provided default_protocol_fee_rate exceeds MAX_PROTOCOL_FEE_RATE."
+            ],
+            "discriminator": [
+                107,
+                205,
+                249,
+                226,
+                151,
+                35,
+                86,
+                0
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "default_protocol_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_delegated_fee_authority",
+            "docs": [
+                "Sets the delegated fee authority for an AdaptiveFeeTier.",
+                "The delegated fee authority can set the fee rate for individual pools initialized with the adaptive fee-tier.",
+                "Only the current fee authority in WhirlpoolsConfig has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                193,
+                234,
+                231,
+                147,
+                138,
+                57,
+                3,
+                122
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_delegated_fee_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_fee_authority",
+            "docs": [
+                "Sets the fee authority for a WhirlpoolConfig.",
+                "The fee authority can set the fee & protocol fee rate for individual pools or",
+                "set the default fee rate for newly minted pools.",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can modify pool fees in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                31,
+                1,
+                50,
+                87,
+                237,
+                101,
+                97,
+                132
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_fee_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_fee_rate",
+            "docs": [
+                "Sets the fee rate for a Whirlpool.",
+                "Fee rate is represented as hundredths of a basis point.",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can modify pool fees in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `fee_rate` - The rate that the pool will use to calculate fees going onwards.",
+                "",
+                "#### Special Errors",
+                "- `FeeRateMaxExceeded` - If the provided fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                53,
+                243,
+                137,
+                65,
+                8,
+                140,
+                158,
+                6
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_fee_rate_by_delegated_fee_authority",
+            "docs": [
+                "Sets the fee rate for a Whirlpool by the delegated fee authority in AdaptiveFeeTier.",
+                "Fee rate is represented as hundredths of a basis point.",
+                "",
+                "### Authority",
+                "- \"delegated_fee_authority\" - Set authority that can modify pool fees in the AdaptiveFeeTier",
+                "",
+                "### Parameters",
+                "- `fee_rate` - The rate that the pool will use to calculate fees going onwards.",
+                "",
+                "#### Special Errors",
+                "- `FeeRateMaxExceeded` - If the provided fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                121,
+                121,
+                54,
+                114,
+                131,
+                230,
+                162,
+                104
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "adaptive_fee_tier"
+                },
+                {
+                    "name": "delegated_fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_initialize_pool_authority",
+            "docs": [
+                "Sets the initialize pool authority for an AdaptiveFeeTier.",
+                "Only the initialize pool authority can initialize pools with the adaptive fee-tier.",
+                "Only the current fee authority in WhirlpoolsConfig has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                125,
+                43,
+                127,
+                235,
+                149,
+                26,
+                106,
+                236
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_initialize_pool_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_preset_adaptive_fee_constants",
+            "docs": [
+                "Sets the adaptive fee constants for an AdaptiveFeeTier.",
+                "Only the current fee authority in WhirlpoolsConfig has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `filter_period` - Period determine high frequency trading time window. (seconds)",
+                "- `decay_period` - Period determine when the adaptive fee start decrease. (seconds)",
+                "- `reduction_factor` - Adaptive fee rate decrement rate.",
+                "- `adaptive_fee_control_factor` - Adaptive fee control factor.",
+                "- `max_volatility_accumulator` - Max volatility accumulator.",
+                "- `tick_group_size` - Tick group size to define tick group index.",
+                "- `major_swap_threshold_ticks` - Major swap threshold ticks to define major swap."
+            ],
+            "discriminator": [
+                132,
+                185,
+                66,
+                148,
+                83,
+                88,
+                134,
+                198
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "filter_period",
+                    "type": "u16"
+                },
+                {
+                    "name": "decay_period",
+                    "type": "u16"
+                },
+                {
+                    "name": "reduction_factor",
+                    "type": "u16"
+                },
+                {
+                    "name": "adaptive_fee_control_factor",
+                    "type": "u32"
+                },
+                {
+                    "name": "max_volatility_accumulator",
+                    "type": "u32"
+                },
+                {
+                    "name": "tick_group_size",
+                    "type": "u16"
+                },
+                {
+                    "name": "major_swap_threshold_ticks",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_protocol_fee_rate",
+            "docs": [
+                "Sets the protocol fee rate for a Whirlpool.",
+                "Protocol fee rate is represented as a basis point.",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can modify pool fees in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `protocol_fee_rate` - The rate that the pool will use to calculate protocol fees going onwards.",
+                "",
+                "#### Special Errors",
+                "- `ProtocolFeeRateMaxExceeded` - If the provided default_protocol_fee_rate exceeds MAX_PROTOCOL_FEE_RATE."
+            ],
+            "discriminator": [
+                95,
+                7,
+                4,
+                50,
+                154,
+                79,
+                156,
+                131
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "protocol_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_reward_authority",
+            "docs": [
+                "Set the whirlpool reward authority at the provided `reward_index`.",
+                "Only the current reward authority for this reward index has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - Set authority that can control reward emission for this particular reward.",
+                "",
+                "#### Special Errors",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                34,
+                39,
+                183,
+                252,
+                83,
+                28,
+                85,
+                127
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_reward_authority"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "set_reward_authority_by_super_authority",
+            "docs": [
+                "Set the whirlpool reward authority at the provided `reward_index`.",
+                "Only the current reward super authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - Set authority that can control reward emission for this particular reward.",
+                "",
+                "#### Special Errors",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                240,
+                154,
+                201,
+                198,
+                148,
+                93,
+                56,
+                25
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_emissions_super_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_reward_authority"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "set_reward_emissions",
+            "docs": [
+                "Set the reward emissions for a reward in a Whirlpool.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - assigned authority by the reward_super_authority for the specified",
+                "reward-index in this Whirlpool",
+                "",
+                "### Parameters",
+                "- `reward_index` - The reward index (0 <= index <= NUM_REWARDS) that we'd like to modify.",
+                "- `emissions_per_second_x64` - The amount of rewards emitted in this pool.",
+                "",
+                "#### Special Errors",
+                "- `RewardVaultAmountInsufficient` - The amount of rewards in the reward vault cannot emit",
+                "more than a day of desired emissions.",
+                "- `InvalidTimestamp` - Provided timestamp is not in order with the previous timestamp.",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                13,
+                197,
+                86,
+                168,
+                109,
+                176,
+                27,
+                244
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "reward_vault"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                },
+                {
+                    "name": "emissions_per_second_x64",
+                    "type": "u128"
+                }
+            ]
+        },
+        {
+            "name": "set_reward_emissions_super_authority",
+            "docs": [
+                "Set the whirlpool reward super authority for a WhirlpoolConfig",
+                "Only the current reward super authority has permission to invoke this instruction.",
+                "This instruction will not change the authority on any `WhirlpoolRewardInfo` whirlpool rewards.",
+                "",
+                "### Authority",
+                "- \"reward_emissions_super_authority\" - Set authority that can control reward authorities for all pools in this config space."
+            ],
+            "discriminator": [
+                207,
+                5,
+                200,
+                209,
+                122,
+                56,
+                82,
+                183
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "reward_emissions_super_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_reward_emissions_super_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_reward_emissions_v2",
+            "docs": [
+                "Set the reward emissions for a reward in a Whirlpool.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - assigned authority by the reward_super_authority for the specified",
+                "reward-index in this Whirlpool",
+                "",
+                "### Parameters",
+                "- `reward_index` - The reward index (0 <= index <= NUM_REWARDS) that we'd like to modify.",
+                "- `emissions_per_second_x64` - The amount of rewards emitted in this pool.",
+                "",
+                "#### Special Errors",
+                "- `RewardVaultAmountInsufficient` - The amount of rewards in the reward vault cannot emit",
+                "more than a day of desired emissions.",
+                "- `InvalidTimestamp` - Provided timestamp is not in order with the previous timestamp.",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                114,
+                228,
+                72,
+                32,
+                193,
+                48,
+                160,
+                102
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "reward_vault"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                },
+                {
+                    "name": "emissions_per_second_x64",
+                    "type": "u128"
+                }
+            ]
+        },
+        {
+            "name": "set_token_badge_attribute",
+            "docs": [
+                "Set an attribute on a TokenBadge account.",
+                "",
+                "### Authority",
+                "- \"token_badge_authority\" - Set authority in the WhirlpoolConfigExtension",
+                "",
+                "### Parameters",
+                "- `attribute` - The attribute to set on the TokenBadge account.",
+                "",
+                "#### Special Errors",
+                "- `FeatureIsNotEnabled` - If the feature flag for token badges is not enabled."
+            ],
+            "discriminator": [
+                224,
+                88,
+                65,
+                33,
+                138,
+                147,
+                246,
+                137
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension",
+                        "token_badge"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension"
+                },
+                {
+                    "name": "token_badge_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_mint",
+                    "relations": [
+                        "token_badge"
+                    ]
+                },
+                {
+                    "name": "token_badge",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "attribute",
+                    "type": {
+                        "defined": {
+                            "name": "TokenBadgeAttribute"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "set_token_badge_authority",
+            "docs": [
+                "Sets the token badge authority for a WhirlpoolsConfigExtension.",
+                "Only the config extension authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"config_extension_authority\" - Set authority in the WhirlpoolConfigExtension"
+            ],
+            "discriminator": [
+                207,
+                202,
+                4,
+                32,
+                205,
+                79,
+                13,
+                178
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension",
+                    "writable": true
+                },
+                {
+                    "name": "config_extension_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_token_badge_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "swap",
+            "docs": [
+                "Perform a swap in this Whirlpool",
+                "",
+                "### Authority",
+                "- \"token_authority\" - The authority to withdraw tokens from the input token account.",
+                "",
+                "### Parameters",
+                "- `amount` - The amount of input or output token to swap from (depending on amount_specified_is_input).",
+                "- `other_amount_threshold` - The maximum/minimum of input/output token to swap into (depending on amount_specified_is_input).",
+                "- `sqrt_price_limit` - The maximum/minimum price the swap will swap to.",
+                "- `amount_specified_is_input` - Specifies the token the parameter `amount`represents. If true, the amount represents the input token of the swap.",
+                "- `a_to_b` - The direction of the swap. True if swapping from A to B. False if swapping from B to A.",
+                "",
+                "#### Special Errors",
+                "- `ZeroTradableAmount` - User provided parameter `amount` is 0.",
+                "- `InvalidSqrtPriceLimitDirection` - User provided parameter `sqrt_price_limit` does not match the direction of the trade.",
+                "- `SqrtPriceOutOfBounds` - User provided parameter `sqrt_price_limit` is over Whirlppool's max/min bounds for sqrt-price.",
+                "- `InvalidTickArraySequence` - User provided tick-arrays are not in sequential order required to proceed in this trade direction.",
+                "- `TickArraySequenceInvalidIndex` - The swap loop attempted to access an invalid array index during the query of the next initialized tick.",
+                "- `TickArrayIndexOutofBounds` - The swap loop attempted to access an invalid array index during tick crossing.",
+                "- `LiquidityOverflow` - Liquidity value overflowed 128bits during tick crossing.",
+                "- `InvalidTickSpacing` - The swap pool was initialized with tick-spacing of 0."
+            ],
+            "discriminator": [
+                248,
+                198,
+                158,
+                145,
+                225,
+                117,
+                135,
+                200
+            ],
+            "accounts": [
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "token_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_2",
+                    "writable": true
+                },
+                {
+                    "name": "oracle",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "args": [
+                {
+                    "name": "amount",
+                    "type": "u64"
+                },
+                {
+                    "name": "other_amount_threshold",
+                    "type": "u64"
+                },
+                {
+                    "name": "sqrt_price_limit",
+                    "type": "u128"
+                },
+                {
+                    "name": "amount_specified_is_input",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b",
+                    "type": "bool"
+                }
+            ]
+        },
+        {
+            "name": "swap_v2",
+            "docs": [
+                "Perform a swap in this Whirlpool",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- \"token_authority\" - The authority to withdraw tokens from the input token account.",
+                "",
+                "### Parameters",
+                "- `amount` - The amount of input or output token to swap from (depending on amount_specified_is_input).",
+                "- `other_amount_threshold` - The maximum/minimum of input/output token to swap into (depending on amount_specified_is_input).",
+                "- `sqrt_price_limit` - The maximum/minimum price the swap will swap to.",
+                "- `amount_specified_is_input` - Specifies the token the parameter `amount`represents. If true, the amount represents the input token of the swap.",
+                "- `a_to_b` - The direction of the swap. True if swapping from A to B. False if swapping from B to A.",
+                "",
+                "#### Special Errors",
+                "- `ZeroTradableAmount` - User provided parameter `amount` is 0.",
+                "- `InvalidSqrtPriceLimitDirection` - User provided parameter `sqrt_price_limit` does not match the direction of the trade.",
+                "- `SqrtPriceOutOfBounds` - User provided parameter `sqrt_price_limit` is over Whirlppool's max/min bounds for sqrt-price.",
+                "- `InvalidTickArraySequence` - User provided tick-arrays are not in sequential order required to proceed in this trade direction.",
+                "- `TickArraySequenceInvalidIndex` - The swap loop attempted to access an invalid array index during the query of the next initialized tick.",
+                "- `TickArrayIndexOutofBounds` - The swap loop attempted to access an invalid array index during tick crossing.",
+                "- `LiquidityOverflow` - Liquidity value overflowed 128bits during tick crossing.",
+                "- `InvalidTickSpacing` - The swap pool was initialized with tick-spacing of 0."
+            ],
+            "discriminator": [
+                43,
+                4,
+                237,
+                11,
+                26,
+                201,
+                30,
+                98
+            ],
+            "accounts": [
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "token_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_2",
+                    "writable": true
+                },
+                {
+                    "name": "oracle",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "args": [
+                {
+                    "name": "amount",
+                    "type": "u64"
+                },
+                {
+                    "name": "other_amount_threshold",
+                    "type": "u64"
+                },
+                {
+                    "name": "sqrt_price_limit",
+                    "type": "u128"
+                },
+                {
+                    "name": "amount_specified_is_input",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b",
+                    "type": "bool"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "transfer_locked_position",
+            "docs": [
+                "Transfer a locked position to a different token account.",
+                "",
+                "### Authority",
+                "- `position_authority` - The authority that owns the position token."
+            ],
+            "discriminator": [
+                179,
+                121,
+                229,
+                46,
+                67,
+                138,
+                194,
+                138
+            ],
+            "accounts": [
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                },
+                {
+                    "name": "position",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    },
+                    "relations": [
+                        "lock_config"
+                    ]
+                },
+                {
+                    "name": "position_mint"
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "destination_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "lock_config",
+                    "writable": true
+                },
+                {
+                    "name": "token_2022_program",
+                    "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "two_hop_swap",
+            "docs": [
+                "Perform a two-hop swap in this Whirlpool",
+                "",
+                "### Authority",
+                "- \"token_authority\" - The authority to withdraw tokens from the input token account.",
+                "",
+                "### Parameters",
+                "- `amount` - The amount of input or output token to swap from (depending on amount_specified_is_input).",
+                "- `other_amount_threshold` - The maximum/minimum of input/output token to swap into (depending on amount_specified_is_input).",
+                "- `amount_specified_is_input` - Specifies the token the parameter `amount`represents. If true, the amount represents the input token of the swap.",
+                "- `a_to_b_one` - The direction of the swap of hop one. True if swapping from A to B. False if swapping from B to A.",
+                "- `a_to_b_two` - The direction of the swap of hop two. True if swapping from A to B. False if swapping from B to A.",
+                "- `sqrt_price_limit_one` - The maximum/minimum price the swap will swap to in the first hop.",
+                "- `sqrt_price_limit_two` - The maximum/minimum price the swap will swap to in the second hop.",
+                "",
+                "#### Special Errors",
+                "- `ZeroTradableAmount` - User provided parameter `amount` is 0.",
+                "- `InvalidSqrtPriceLimitDirection` - User provided parameter `sqrt_price_limit` does not match the direction of the trade.",
+                "- `SqrtPriceOutOfBounds` - User provided parameter `sqrt_price_limit` is over Whirlppool's max/min bounds for sqrt-price.",
+                "- `InvalidTickArraySequence` - User provided tick-arrays are not in sequential order required to proceed in this trade direction.",
+                "- `TickArraySequenceInvalidIndex` - The swap loop attempted to access an invalid array index during the query of the next initialized tick.",
+                "- `TickArrayIndexOutofBounds` - The swap loop attempted to access an invalid array index during tick crossing.",
+                "- `LiquidityOverflow` - Liquidity value overflowed 128bits during tick crossing.",
+                "- `InvalidTickSpacing` - The swap pool was initialized with tick-spacing of 0.",
+                "- `InvalidIntermediaryMint` - Error if the intermediary mint between hop one and two do not equal.",
+                "- `DuplicateTwoHopPool` - Error if whirlpool one & two are the same pool."
+            ],
+            "discriminator": [
+                195,
+                96,
+                237,
+                108,
+                68,
+                162,
+                219,
+                230
+            ],
+            "accounts": [
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "token_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool_one",
+                    "writable": true
+                },
+                {
+                    "name": "whirlpool_two",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_one_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_one_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_one_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_one_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_two_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_two_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_two_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_two_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_2",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_2",
+                    "writable": true
+                },
+                {
+                    "name": "oracle_one",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool_one"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "oracle_two",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool_two"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "args": [
+                {
+                    "name": "amount",
+                    "type": "u64"
+                },
+                {
+                    "name": "other_amount_threshold",
+                    "type": "u64"
+                },
+                {
+                    "name": "amount_specified_is_input",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b_one",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b_two",
+                    "type": "bool"
+                },
+                {
+                    "name": "sqrt_price_limit_one",
+                    "type": "u128"
+                },
+                {
+                    "name": "sqrt_price_limit_two",
+                    "type": "u128"
+                }
+            ]
+        },
+        {
+            "name": "two_hop_swap_v2",
+            "docs": [
+                "Perform a two-hop swap in this Whirlpool",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- \"token_authority\" - The authority to withdraw tokens from the input token account.",
+                "",
+                "### Parameters",
+                "- `amount` - The amount of input or output token to swap from (depending on amount_specified_is_input).",
+                "- `other_amount_threshold` - The maximum/minimum of input/output token to swap into (depending on amount_specified_is_input).",
+                "- `amount_specified_is_input` - Specifies the token the parameter `amount`represents. If true, the amount represents the input token of the swap.",
+                "- `a_to_b_one` - The direction of the swap of hop one. True if swapping from A to B. False if swapping from B to A.",
+                "- `a_to_b_two` - The direction of the swap of hop two. True if swapping from A to B. False if swapping from B to A.",
+                "- `sqrt_price_limit_one` - The maximum/minimum price the swap will swap to in the first hop.",
+                "- `sqrt_price_limit_two` - The maximum/minimum price the swap will swap to in the second hop.",
+                "",
+                "#### Special Errors",
+                "- `ZeroTradableAmount` - User provided parameter `amount` is 0.",
+                "- `InvalidSqrtPriceLimitDirection` - User provided parameter `sqrt_price_limit` does not match the direction of the trade.",
+                "- `SqrtPriceOutOfBounds` - User provided parameter `sqrt_price_limit` is over Whirlppool's max/min bounds for sqrt-price.",
+                "- `InvalidTickArraySequence` - User provided tick-arrays are not in sequential order required to proceed in this trade direction.",
+                "- `TickArraySequenceInvalidIndex` - The swap loop attempted to access an invalid array index during the query of the next initialized tick.",
+                "- `TickArrayIndexOutofBounds` - The swap loop attempted to access an invalid array index during tick crossing.",
+                "- `LiquidityOverflow` - Liquidity value overflowed 128bits during tick crossing.",
+                "- `InvalidTickSpacing` - The swap pool was initialized with tick-spacing of 0.",
+                "- `InvalidIntermediaryMint` - Error if the intermediary mint between hop one and two do not equal.",
+                "- `DuplicateTwoHopPool` - Error if whirlpool one & two are the same pool."
+            ],
+            "discriminator": [
+                186,
+                143,
+                209,
+                29,
+                254,
+                2,
+                194,
+                117
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool_one",
+                    "writable": true
+                },
+                {
+                    "name": "whirlpool_two",
+                    "writable": true
+                },
+                {
+                    "name": "token_mint_input"
+                },
+                {
+                    "name": "token_mint_intermediate"
+                },
+                {
+                    "name": "token_mint_output"
+                },
+                {
+                    "name": "token_program_input"
+                },
+                {
+                    "name": "token_program_intermediate"
+                },
+                {
+                    "name": "token_program_output"
+                },
+                {
+                    "name": "token_owner_account_input",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_one_input",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_one_intermediate",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_two_intermediate",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_two_output",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_output",
+                    "writable": true
+                },
+                {
+                    "name": "token_authority",
+                    "signer": true
+                },
+                {
+                    "name": "tick_array_one_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_2",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_2",
+                    "writable": true
+                },
+                {
+                    "name": "oracle_one",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool_one"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "oracle_two",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool_two"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "amount",
+                    "type": "u64"
+                },
+                {
+                    "name": "other_amount_threshold",
+                    "type": "u64"
+                },
+                {
+                    "name": "amount_specified_is_input",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b_one",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b_two",
+                    "type": "bool"
+                },
+                {
+                    "name": "sqrt_price_limit_one",
+                    "type": "u128"
+                },
+                {
+                    "name": "sqrt_price_limit_two",
+                    "type": "u128"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "update_fees_and_rewards",
+            "docs": [
+                "Update the accrued fees and rewards for a position.",
+                "",
+                "#### Special Errors",
+                "- `TickNotFound` - Provided tick array account does not contain the tick for this position.",
+                "- `LiquidityZero` - Position has zero liquidity and therefore already has the most updated fees and reward values."
+            ],
+            "discriminator": [
+                154,
+                230,
+                250,
+                13,
+                236,
+                209,
+                75,
+                223
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower"
+                },
+                {
+                    "name": "tick_array_upper"
+                }
+            ],
+            "args": []
         }
-      ]
-    },
-    {
-      "name": "LiquidityIncreased",
-      "fields": [
+    ],
+    "accounts": [
         {
-          "name": "whirlpool",
-          "type": "publicKey",
-          "index": false
+            "name": "AdaptiveFeeTier",
+            "discriminator": [
+                147,
+                16,
+                144,
+                116,
+                47,
+                146,
+                149,
+                46
+            ]
         },
         {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
+            "name": "DynamicTickArray",
+            "discriminator": [
+                17,
+                216,
+                246,
+                142,
+                225,
+                199,
+                218,
+                56
+            ]
         },
         {
-          "name": "tickLowerIndex",
-          "type": "i32",
-          "index": false
+            "name": "FeeTier",
+            "discriminator": [
+                56,
+                75,
+                159,
+                76,
+                142,
+                68,
+                190,
+                105
+            ]
         },
         {
-          "name": "tickUpperIndex",
-          "type": "i32",
-          "index": false
+            "name": "LockConfig",
+            "discriminator": [
+                106,
+                47,
+                238,
+                159,
+                124,
+                12,
+                160,
+                192
+            ]
         },
         {
-          "name": "liquidity",
-          "type": "u128",
-          "index": false
+            "name": "Oracle",
+            "discriminator": [
+                139,
+                194,
+                131,
+                179,
+                140,
+                179,
+                229,
+                244
+            ]
         },
         {
-          "name": "tokenAAmount",
-          "type": "u64",
-          "index": false
+            "name": "Position",
+            "discriminator": [
+                170,
+                188,
+                143,
+                228,
+                122,
+                64,
+                247,
+                208
+            ]
         },
         {
-          "name": "tokenBAmount",
-          "type": "u64",
-          "index": false
+            "name": "PositionBundle",
+            "discriminator": [
+                129,
+                169,
+                175,
+                65,
+                185,
+                95,
+                32,
+                100
+            ]
         },
         {
-          "name": "tokenATransferFee",
-          "type": "u64",
-          "index": false
+            "name": "TickArray",
+            "discriminator": [
+                69,
+                97,
+                189,
+                190,
+                110,
+                7,
+                66,
+                187
+            ]
         },
         {
-          "name": "tokenBTransferFee",
-          "type": "u64",
-          "index": false
+            "name": "TokenBadge",
+            "discriminator": [
+                116,
+                219,
+                204,
+                229,
+                249,
+                116,
+                255,
+                150
+            ]
+        },
+        {
+            "name": "Whirlpool",
+            "discriminator": [
+                63,
+                149,
+                209,
+                12,
+                225,
+                128,
+                99,
+                9
+            ]
+        },
+        {
+            "name": "WhirlpoolsConfig",
+            "discriminator": [
+                157,
+                20,
+                49,
+                224,
+                217,
+                87,
+                193,
+                254
+            ]
+        },
+        {
+            "name": "WhirlpoolsConfigExtension",
+            "discriminator": [
+                2,
+                99,
+                215,
+                163,
+                240,
+                26,
+                153,
+                58
+            ]
         }
-      ]
-    },
-    {
-      "name": "PoolInitialized",
-      "fields": [
+    ],
+    "events": [
         {
-          "name": "whirlpool",
-          "type": "publicKey",
-          "index": false
+            "name": "LiquidityDecreased",
+            "discriminator": [
+                166,
+                1,
+                36,
+                71,
+                112,
+                202,
+                181,
+                171
+            ]
         },
         {
-          "name": "whirlpoolsConfig",
-          "type": "publicKey",
-          "index": false
+            "name": "LiquidityIncreased",
+            "discriminator": [
+                30,
+                7,
+                144,
+                181,
+                102,
+                254,
+                155,
+                161
+            ]
         },
         {
-          "name": "tokenMintA",
-          "type": "publicKey",
-          "index": false
+            "name": "LiquidityRepositioned",
+            "discriminator": [
+                95,
+                130,
+                181,
+                132,
+                251,
+                50,
+                195,
+                38
+            ]
         },
         {
-          "name": "tokenMintB",
-          "type": "publicKey",
-          "index": false
+            "name": "PoolInitialized",
+            "discriminator": [
+                100,
+                118,
+                173,
+                87,
+                12,
+                198,
+                254,
+                229
+            ]
         },
         {
-          "name": "tickSpacing",
-          "type": "u16",
-          "index": false
+            "name": "PositionOpened",
+            "discriminator": [
+                237,
+                175,
+                243,
+                230,
+                147,
+                117,
+                101,
+                121
+            ]
         },
         {
-          "name": "tokenProgramA",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "tokenProgramB",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "decimalsA",
-          "type": "u8",
-          "index": false
-        },
-        {
-          "name": "decimalsB",
-          "type": "u8",
-          "index": false
-        },
-        {
-          "name": "initialSqrtPrice",
-          "type": "u128",
-          "index": false
+            "name": "Traded",
+            "discriminator": [
+                225,
+                202,
+                73,
+                175,
+                147,
+                43,
+                160,
+                150
+            ]
         }
-      ]
-    },
-    {
-      "name": "Traded",
-      "fields": [
+    ],
+    "errors": [
         {
-          "name": "whirlpool",
-          "type": "publicKey",
-          "index": false
+            "code": 6000,
+            "name": "InvalidEnum",
+            "msg": "Enum value could not be converted"
         },
         {
-          "name": "aToB",
-          "type": "bool",
-          "index": false
+            "code": 6001,
+            "name": "InvalidStartTick",
+            "msg": "Invalid start tick index provided."
         },
         {
-          "name": "preSqrtPrice",
-          "type": "u128",
-          "index": false
+            "code": 6002,
+            "name": "TickArrayExistInPool",
+            "msg": "Tick-array already exists in this whirlpool"
         },
         {
-          "name": "postSqrtPrice",
-          "type": "u128",
-          "index": false
+            "code": 6003,
+            "name": "TickArrayIndexOutofBounds",
+            "msg": "Attempt to search for a tick-array failed"
         },
         {
-          "name": "inputAmount",
-          "type": "u64",
-          "index": false
+            "code": 6004,
+            "name": "InvalidTickSpacing",
+            "msg": "Tick-spacing is not supported"
         },
         {
-          "name": "outputAmount",
-          "type": "u64",
-          "index": false
+            "code": 6005,
+            "name": "ClosePositionNotEmpty",
+            "msg": "Position is not empty It cannot be closed"
         },
         {
-          "name": "inputTransferFee",
-          "type": "u64",
-          "index": false
+            "code": 6006,
+            "name": "DivideByZero",
+            "msg": "Unable to divide by zero"
         },
         {
-          "name": "outputTransferFee",
-          "type": "u64",
-          "index": false
+            "code": 6007,
+            "name": "NumberCastError",
+            "msg": "Unable to cast number into BigInt"
         },
         {
-          "name": "lpFee",
-          "type": "u64",
-          "index": false
+            "code": 6008,
+            "name": "NumberDownCastError",
+            "msg": "Unable to down cast number"
         },
         {
-          "name": "protocolFee",
-          "type": "u64",
-          "index": false
+            "code": 6009,
+            "name": "TickNotFound",
+            "msg": "Tick not found within tick array"
+        },
+        {
+            "code": 6010,
+            "name": "InvalidTickIndex",
+            "msg": "Provided tick index is either out of bounds or uninitializable"
+        },
+        {
+            "code": 6011,
+            "name": "SqrtPriceOutOfBounds",
+            "msg": "Provided sqrt price out of bounds"
+        },
+        {
+            "code": 6012,
+            "name": "LiquidityZero",
+            "msg": "Liquidity amount must be greater than zero"
+        },
+        {
+            "code": 6013,
+            "name": "LiquidityTooHigh",
+            "msg": "Liquidity amount must be less than i64::MAX"
+        },
+        {
+            "code": 6014,
+            "name": "LiquidityOverflow",
+            "msg": "Liquidity overflow"
+        },
+        {
+            "code": 6015,
+            "name": "LiquidityUnderflow",
+            "msg": "Liquidity underflow"
+        },
+        {
+            "code": 6016,
+            "name": "LiquidityNetError",
+            "msg": "Tick liquidity net underflowed or overflowed"
+        },
+        {
+            "code": 6017,
+            "name": "TokenMaxExceeded",
+            "msg": "Exceeded token max"
+        },
+        {
+            "code": 6018,
+            "name": "TokenMinSubceeded",
+            "msg": "Did not meet token min"
+        },
+        {
+            "code": 6019,
+            "name": "MissingOrInvalidDelegate",
+            "msg": "Position token account has a missing or invalid delegate"
+        },
+        {
+            "code": 6020,
+            "name": "InvalidPositionTokenAmount",
+            "msg": "Position token amount must be 1"
+        },
+        {
+            "code": 6021,
+            "name": "InvalidTimestampConversion",
+            "msg": "Timestamp should be convertible from i64 to u64"
+        },
+        {
+            "code": 6022,
+            "name": "InvalidTimestamp",
+            "msg": "Timestamp should be greater than the last updated timestamp"
+        },
+        {
+            "code": 6023,
+            "name": "InvalidTickArraySequence",
+            "msg": "Invalid tick array sequence provided for instruction."
+        },
+        {
+            "code": 6024,
+            "name": "InvalidTokenMintOrder",
+            "msg": "Token Mint in wrong order"
+        },
+        {
+            "code": 6025,
+            "name": "RewardNotInitialized",
+            "msg": "Reward not initialized"
+        },
+        {
+            "code": 6026,
+            "name": "InvalidRewardIndex",
+            "msg": "Invalid reward index"
+        },
+        {
+            "code": 6027,
+            "name": "RewardVaultAmountInsufficient",
+            "msg": "Reward vault requires amount to support emissions for at least one day"
+        },
+        {
+            "code": 6028,
+            "name": "FeeRateMaxExceeded",
+            "msg": "Exceeded max fee rate"
+        },
+        {
+            "code": 6029,
+            "name": "ProtocolFeeRateMaxExceeded",
+            "msg": "Exceeded max protocol fee rate"
+        },
+        {
+            "code": 6030,
+            "name": "MultiplicationShiftRightOverflow",
+            "msg": "Multiplication with shift right overflow"
+        },
+        {
+            "code": 6031,
+            "name": "MulDivOverflow",
+            "msg": "Muldiv overflow"
+        },
+        {
+            "code": 6032,
+            "name": "MulDivInvalidInput",
+            "msg": "Invalid div_u256 input"
+        },
+        {
+            "code": 6033,
+            "name": "MultiplicationOverflow",
+            "msg": "Multiplication overflow"
+        },
+        {
+            "code": 6034,
+            "name": "InvalidSqrtPriceLimitDirection",
+            "msg": "Provided SqrtPriceLimit not in the same direction as the swap."
+        },
+        {
+            "code": 6035,
+            "name": "ZeroTradableAmount",
+            "msg": "There are no tradable amount to swap."
+        },
+        {
+            "code": 6036,
+            "name": "AmountOutBelowMinimum",
+            "msg": "Amount out below minimum threshold"
+        },
+        {
+            "code": 6037,
+            "name": "AmountInAboveMaximum",
+            "msg": "Amount in above maximum threshold"
+        },
+        {
+            "code": 6038,
+            "name": "TickArraySequenceInvalidIndex",
+            "msg": "Invalid index for tick array sequence"
+        },
+        {
+            "code": 6039,
+            "name": "AmountCalcOverflow",
+            "msg": "Amount calculated overflows"
+        },
+        {
+            "code": 6040,
+            "name": "AmountRemainingOverflow",
+            "msg": "Amount remaining overflows"
+        },
+        {
+            "code": 6041,
+            "name": "InvalidIntermediaryMint",
+            "msg": "Invalid intermediary mint"
+        },
+        {
+            "code": 6042,
+            "name": "DuplicateTwoHopPool",
+            "msg": "Duplicate two hop pool"
+        },
+        {
+            "code": 6043,
+            "name": "InvalidBundleIndex",
+            "msg": "Bundle index is out of bounds"
+        },
+        {
+            "code": 6044,
+            "name": "BundledPositionAlreadyOpened",
+            "msg": "Position has already been opened"
+        },
+        {
+            "code": 6045,
+            "name": "BundledPositionAlreadyClosed",
+            "msg": "Position has already been closed"
+        },
+        {
+            "code": 6046,
+            "name": "PositionBundleNotDeletable",
+            "msg": "Unable to delete PositionBundle with open positions"
+        },
+        {
+            "code": 6047,
+            "name": "UnsupportedTokenMint",
+            "msg": "Token mint has unsupported attributes"
+        },
+        {
+            "code": 6048,
+            "name": "RemainingAccountsInvalidSlice",
+            "msg": "Invalid remaining accounts"
+        },
+        {
+            "code": 6049,
+            "name": "RemainingAccountsInsufficient",
+            "msg": "Insufficient remaining accounts"
+        },
+        {
+            "code": 6050,
+            "name": "NoExtraAccountsForTransferHook",
+            "msg": "Unable to call transfer hook without extra accounts"
+        },
+        {
+            "code": 6051,
+            "name": "IntermediateTokenAmountMismatch",
+            "msg": "Output and input amount mismatch"
+        },
+        {
+            "code": 6052,
+            "name": "TransferFeeCalculationError",
+            "msg": "Transfer fee calculation failed"
+        },
+        {
+            "code": 6053,
+            "name": "RemainingAccountsDuplicatedAccountsType",
+            "msg": "Same accounts type is provided more than once"
+        },
+        {
+            "code": 6054,
+            "name": "FullRangeOnlyPool",
+            "msg": "This whirlpool only supports full-range positions"
+        },
+        {
+            "code": 6055,
+            "name": "TooManySupplementalTickArrays",
+            "msg": "Too many supplemental tick arrays provided"
+        },
+        {
+            "code": 6056,
+            "name": "DifferentWhirlpoolTickArrayAccount",
+            "msg": "TickArray account for different whirlpool provided"
+        },
+        {
+            "code": 6057,
+            "name": "PartialFillError",
+            "msg": "Trade resulted in partial fill"
+        },
+        {
+            "code": 6058,
+            "name": "PositionNotLockable",
+            "msg": "Position is not lockable"
+        },
+        {
+            "code": 6059,
+            "name": "OperationNotAllowedOnLockedPosition",
+            "msg": "Operation not allowed on locked position"
+        },
+        {
+            "code": 6060,
+            "name": "SameTickRangeNotAllowed",
+            "msg": "Cannot reset position range with same tick range"
+        },
+        {
+            "code": 6061,
+            "name": "InvalidAdaptiveFeeConstants",
+            "msg": "Invalid adaptive fee constants"
+        },
+        {
+            "code": 6062,
+            "name": "InvalidFeeTierIndex",
+            "msg": "Invalid fee tier index"
+        },
+        {
+            "code": 6063,
+            "name": "InvalidTradeEnableTimestamp",
+            "msg": "Invalid trade enable timestamp"
+        },
+        {
+            "code": 6064,
+            "name": "TradeIsNotEnabled",
+            "msg": "Trade is not enabled yet"
+        },
+        {
+            "code": 6065,
+            "name": "RentCalculationError",
+            "msg": "Rent calculation error"
+        },
+        {
+            "code": 6066,
+            "name": "FeatureIsNotEnabled",
+            "msg": "Feature is not enabled"
+        },
+        {
+            "code": 6067,
+            "name": "PositionWithTokenExtensionsRequired",
+            "msg": "This whirlpool only supports open_position_with_token_extensions instruction"
+        },
+        {
+            "code": 6068,
+            "name": "AdaptiveFeeConstantsUnchanged",
+            "msg": "Provided adaptive fee constants are unchanged"
+        },
+        {
+            "code": 6069,
+            "name": "PriceSlippageOutOfBounds",
+            "msg": "Price outside slippage bounds"
         }
-      ]
-    }
-  ],
-  "errors": [
-    {
-      "code": 6000,
-      "name": "InvalidEnum",
-      "msg": "Enum value could not be converted"
-    },
-    {
-      "code": 6001,
-      "name": "InvalidStartTick",
-      "msg": "Invalid start tick index provided."
-    },
-    {
-      "code": 6002,
-      "name": "TickArrayExistInPool",
-      "msg": "Tick-array already exists in this whirlpool"
-    },
-    {
-      "code": 6003,
-      "name": "TickArrayIndexOutofBounds",
-      "msg": "Attempt to search for a tick-array failed"
-    },
-    {
-      "code": 6004,
-      "name": "InvalidTickSpacing",
-      "msg": "Tick-spacing is not supported"
-    },
-    {
-      "code": 6005,
-      "name": "ClosePositionNotEmpty",
-      "msg": "Position is not empty It cannot be closed"
-    },
-    {
-      "code": 6006,
-      "name": "DivideByZero",
-      "msg": "Unable to divide by zero"
-    },
-    {
-      "code": 6007,
-      "name": "NumberCastError",
-      "msg": "Unable to cast number into BigInt"
-    },
-    {
-      "code": 6008,
-      "name": "NumberDownCastError",
-      "msg": "Unable to down cast number"
-    },
-    {
-      "code": 6009,
-      "name": "TickNotFound",
-      "msg": "Tick not found within tick array"
-    },
-    {
-      "code": 6010,
-      "name": "InvalidTickIndex",
-      "msg": "Provided tick index is either out of bounds or uninitializable"
-    },
-    {
-      "code": 6011,
-      "name": "SqrtPriceOutOfBounds",
-      "msg": "Provided sqrt price out of bounds"
-    },
-    {
-      "code": 6012,
-      "name": "LiquidityZero",
-      "msg": "Liquidity amount must be greater than zero"
-    },
-    {
-      "code": 6013,
-      "name": "LiquidityTooHigh",
-      "msg": "Liquidity amount must be less than i64::MAX"
-    },
-    {
-      "code": 6014,
-      "name": "LiquidityOverflow",
-      "msg": "Liquidity overflow"
-    },
-    {
-      "code": 6015,
-      "name": "LiquidityUnderflow",
-      "msg": "Liquidity underflow"
-    },
-    {
-      "code": 6016,
-      "name": "LiquidityNetError",
-      "msg": "Tick liquidity net underflowed or overflowed"
-    },
-    {
-      "code": 6017,
-      "name": "TokenMaxExceeded",
-      "msg": "Exceeded token max"
-    },
-    {
-      "code": 6018,
-      "name": "TokenMinSubceeded",
-      "msg": "Did not meet token min"
-    },
-    {
-      "code": 6019,
-      "name": "MissingOrInvalidDelegate",
-      "msg": "Position token account has a missing or invalid delegate"
-    },
-    {
-      "code": 6020,
-      "name": "InvalidPositionTokenAmount",
-      "msg": "Position token amount must be 1"
-    },
-    {
-      "code": 6021,
-      "name": "InvalidTimestampConversion",
-      "msg": "Timestamp should be convertible from i64 to u64"
-    },
-    {
-      "code": 6022,
-      "name": "InvalidTimestamp",
-      "msg": "Timestamp should be greater than the last updated timestamp"
-    },
-    {
-      "code": 6023,
-      "name": "InvalidTickArraySequence",
-      "msg": "Invalid tick array sequence provided for instruction."
-    },
-    {
-      "code": 6024,
-      "name": "InvalidTokenMintOrder",
-      "msg": "Token Mint in wrong order"
-    },
-    {
-      "code": 6025,
-      "name": "RewardNotInitialized",
-      "msg": "Reward not initialized"
-    },
-    {
-      "code": 6026,
-      "name": "InvalidRewardIndex",
-      "msg": "Invalid reward index"
-    },
-    {
-      "code": 6027,
-      "name": "RewardVaultAmountInsufficient",
-      "msg": "Reward vault requires amount to support emissions for at least one day"
-    },
-    {
-      "code": 6028,
-      "name": "FeeRateMaxExceeded",
-      "msg": "Exceeded max fee rate"
-    },
-    {
-      "code": 6029,
-      "name": "ProtocolFeeRateMaxExceeded",
-      "msg": "Exceeded max protocol fee rate"
-    },
-    {
-      "code": 6030,
-      "name": "MultiplicationShiftRightOverflow",
-      "msg": "Multiplication with shift right overflow"
-    },
-    {
-      "code": 6031,
-      "name": "MulDivOverflow",
-      "msg": "Muldiv overflow"
-    },
-    {
-      "code": 6032,
-      "name": "MulDivInvalidInput",
-      "msg": "Invalid div_u256 input"
-    },
-    {
-      "code": 6033,
-      "name": "MultiplicationOverflow",
-      "msg": "Multiplication overflow"
-    },
-    {
-      "code": 6034,
-      "name": "InvalidSqrtPriceLimitDirection",
-      "msg": "Provided SqrtPriceLimit not in the same direction as the swap."
-    },
-    {
-      "code": 6035,
-      "name": "ZeroTradableAmount",
-      "msg": "There are no tradable amount to swap."
-    },
-    {
-      "code": 6036,
-      "name": "AmountOutBelowMinimum",
-      "msg": "Amount out below minimum threshold"
-    },
-    {
-      "code": 6037,
-      "name": "AmountInAboveMaximum",
-      "msg": "Amount in above maximum threshold"
-    },
-    {
-      "code": 6038,
-      "name": "TickArraySequenceInvalidIndex",
-      "msg": "Invalid index for tick array sequence"
-    },
-    {
-      "code": 6039,
-      "name": "AmountCalcOverflow",
-      "msg": "Amount calculated overflows"
-    },
-    {
-      "code": 6040,
-      "name": "AmountRemainingOverflow",
-      "msg": "Amount remaining overflows"
-    },
-    {
-      "code": 6041,
-      "name": "InvalidIntermediaryMint",
-      "msg": "Invalid intermediary mint"
-    },
-    {
-      "code": 6042,
-      "name": "DuplicateTwoHopPool",
-      "msg": "Duplicate two hop pool"
-    },
-    {
-      "code": 6043,
-      "name": "InvalidBundleIndex",
-      "msg": "Bundle index is out of bounds"
-    },
-    {
-      "code": 6044,
-      "name": "BundledPositionAlreadyOpened",
-      "msg": "Position has already been opened"
-    },
-    {
-      "code": 6045,
-      "name": "BundledPositionAlreadyClosed",
-      "msg": "Position has already been closed"
-    },
-    {
-      "code": 6046,
-      "name": "PositionBundleNotDeletable",
-      "msg": "Unable to delete PositionBundle with open positions"
-    },
-    {
-      "code": 6047,
-      "name": "UnsupportedTokenMint",
-      "msg": "Token mint has unsupported attributes"
-    },
-    {
-      "code": 6048,
-      "name": "RemainingAccountsInvalidSlice",
-      "msg": "Invalid remaining accounts"
-    },
-    {
-      "code": 6049,
-      "name": "RemainingAccountsInsufficient",
-      "msg": "Insufficient remaining accounts"
-    },
-    {
-      "code": 6050,
-      "name": "NoExtraAccountsForTransferHook",
-      "msg": "Unable to call transfer hook without extra accounts"
-    },
-    {
-      "code": 6051,
-      "name": "IntermediateTokenAmountMismatch",
-      "msg": "Output and input amount mismatch"
-    },
-    {
-      "code": 6052,
-      "name": "TransferFeeCalculationError",
-      "msg": "Transfer fee calculation failed"
-    },
-    {
-      "code": 6053,
-      "name": "RemainingAccountsDuplicatedAccountsType",
-      "msg": "Same accounts type is provided more than once"
-    },
-    {
-      "code": 6054,
-      "name": "FullRangeOnlyPool",
-      "msg": "This whirlpool only supports full-range positions"
-    },
-    {
-      "code": 6055,
-      "name": "TooManySupplementalTickArrays",
-      "msg": "Too many supplemental tick arrays provided"
-    },
-    {
-      "code": 6056,
-      "name": "DifferentWhirlpoolTickArrayAccount",
-      "msg": "TickArray account for different whirlpool provided"
-    },
-    {
-      "code": 6057,
-      "name": "PartialFillError",
-      "msg": "Trade resulted in partial fill"
-    },
-    {
-      "code": 6058,
-      "name": "PositionNotLockable",
-      "msg": "Position is not lockable"
-    },
-    {
-      "code": 6059,
-      "name": "OperationNotAllowedOnLockedPosition",
-      "msg": "Operation not allowed on locked position"
-    },
-    {
-      "code": 6060,
-      "name": "SameTickRangeNotAllowed",
-      "msg": "Cannot reset position range with same tick range"
-    },
-    {
-      "code": 6061,
-      "name": "InvalidAdaptiveFeeConstants",
-      "msg": "Invalid adaptive fee constants"
-    },
-    {
-      "code": 6062,
-      "name": "InvalidFeeTierIndex",
-      "msg": "Invalid fee tier index"
-    },
-    {
-      "code": 6063,
-      "name": "InvalidTradeEnableTimestamp",
-      "msg": "Invalid trade enable timestamp"
-    },
-    {
-      "code": 6064,
-      "name": "TradeIsNotEnabled",
-      "msg": "Trade is not enabled yet"
-    }
-  ]
+    ],
+    "types": [
+        {
+            "name": "AccountsType",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "TransferHookA"
+                    },
+                    {
+                        "name": "TransferHookB"
+                    },
+                    {
+                        "name": "TransferHookReward"
+                    },
+                    {
+                        "name": "TransferHookInput"
+                    },
+                    {
+                        "name": "TransferHookIntermediate"
+                    },
+                    {
+                        "name": "TransferHookOutput"
+                    },
+                    {
+                        "name": "SupplementalTickArrays"
+                    },
+                    {
+                        "name": "SupplementalTickArraysOne"
+                    },
+                    {
+                        "name": "SupplementalTickArraysTwo"
+                    },
+                    {
+                        "name": "TransferHookDepositA"
+                    },
+                    {
+                        "name": "TransferHookDepositB"
+                    },
+                    {
+                        "name": "TransferHookWithdrawalA"
+                    },
+                    {
+                        "name": "TransferHookWithdrawalB"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "AdaptiveFeeConstants",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "filter_period",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "decay_period",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "reduction_factor",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "adaptive_fee_control_factor",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "max_volatility_accumulator",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "tick_group_size",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "major_swap_threshold_ticks",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "reserved",
+                        "type": {
+                            "array": [
+                                "u8",
+                                16
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "AdaptiveFeeTier",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "fee_tier_index",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "tick_spacing",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "initialize_pool_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "delegated_fee_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "default_base_fee_rate",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "filter_period",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "decay_period",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "reduction_factor",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "adaptive_fee_control_factor",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "max_volatility_accumulator",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "tick_group_size",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "major_swap_threshold_ticks",
+                        "type": "u16"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "AdaptiveFeeVariables",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "last_reference_update_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "last_major_swap_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "volatility_reference",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "tick_group_index_reference",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "volatility_accumulator",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "reserved",
+                        "type": {
+                            "array": [
+                                "u8",
+                                16
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "ConfigFeatureFlag",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "TokenBadge",
+                        "fields": [
+                            "bool"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "DynamicTick",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "Uninitialized"
+                    },
+                    {
+                        "name": "Initialized",
+                        "fields": [
+                            {
+                                "defined": {
+                                    "name": "DynamicTickData"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "DynamicTickArray",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "start_tick_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_bitmap",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "ticks",
+                        "type": {
+                            "array": [
+                                {
+                                    "defined": {
+                                        "name": "DynamicTick"
+                                    }
+                                },
+                                88
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "DynamicTickData",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "liquidity_net",
+                        "type": "i128"
+                    },
+                    {
+                        "name": "liquidity_gross",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_growth_outside_a",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_growth_outside_b",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "reward_growths_outside",
+                        "type": {
+                            "array": [
+                                "u128",
+                                3
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "FeeTier",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_spacing",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "default_fee_rate",
+                        "type": "u16"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "IncreaseLiquidityMethod",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "ByTokenAmounts",
+                        "fields": [
+                            {
+                                "name": "token_max_a",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "token_max_b",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "min_sqrt_price",
+                                "type": "u128"
+                            },
+                            {
+                                "name": "max_sqrt_price",
+                                "type": "u128"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LiquidityDecreased",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "token_a_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_a_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_transfer_fee",
+                        "type": "u64"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LiquidityIncreased",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "token_a_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_a_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_transfer_fee",
+                        "type": "u64"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LiquidityRepositioned",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "existing_range_tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "existing_range_tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "new_range_tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "new_range_tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "existing_range_liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "new_range_liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "existing_range_token_a_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "existing_range_token_b_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "new_range_token_a_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "new_range_token_b_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_a_transfer_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_a_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "is_token_a_transfer_from_owner",
+                        "type": "bool"
+                    },
+                    {
+                        "name": "token_b_transfer_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "is_token_b_transfer_from_owner",
+                        "type": "bool"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LockConfig",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position_owner",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "locked_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "lock_type",
+                        "type": {
+                            "defined": {
+                                "name": "LockTypeLabel"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LockType",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "Permanent"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LockTypeLabel",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "Permanent"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "OpenPositionBumps",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "position_bump",
+                        "type": "u8"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "OpenPositionWithMetadataBumps",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "position_bump",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "metadata_bump",
+                        "type": "u8"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Oracle",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "trade_enable_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "adaptive_fee_constants",
+                        "type": {
+                            "defined": {
+                                "name": "AdaptiveFeeConstants"
+                            }
+                        }
+                    },
+                    {
+                        "name": "adaptive_fee_variables",
+                        "type": {
+                            "defined": {
+                                "name": "AdaptiveFeeVariables"
+                            }
+                        }
+                    },
+                    {
+                        "name": "reserved",
+                        "type": {
+                            "array": [
+                                "u8",
+                                128
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "PoolInitialized",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_mint_a",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_mint_b",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_spacing",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "token_program_a",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_program_b",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "decimals_a",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "decimals_b",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "initial_sqrt_price",
+                        "type": "u128"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Position",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position_mint",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "fee_growth_checkpoint_a",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_owed_a",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "fee_growth_checkpoint_b",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_owed_b",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "reward_infos",
+                        "type": {
+                            "array": [
+                                {
+                                    "defined": {
+                                        "name": "PositionRewardInfo"
+                                    }
+                                },
+                                3
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "PositionBundle",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "position_bundle_mint",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position_bitmap",
+                        "type": {
+                            "array": [
+                                "u8",
+                                32
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "PositionOpened",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "tick_upper_index",
+                        "type": "i32"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "PositionRewardInfo",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "growth_inside_checkpoint",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "amount_owed",
+                        "type": "u64"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "RemainingAccountsInfo",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "slices",
+                        "type": {
+                            "vec": {
+                                "defined": {
+                                    "name": "RemainingAccountsSlice"
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "RemainingAccountsSlice",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "accounts_type",
+                        "type": {
+                            "defined": {
+                                "name": "AccountsType"
+                            }
+                        }
+                    },
+                    {
+                        "name": "length",
+                        "type": "u8"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "RepositionLiquidityMethod",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "ByLiquidity",
+                        "fields": [
+                            {
+                                "name": "new_liquidity_amount",
+                                "type": "u128"
+                            },
+                            {
+                                "name": "existing_range_token_min_a",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "existing_range_token_min_b",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "new_range_token_max_a",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "new_range_token_max_b",
+                                "type": "u64"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Tick",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "initialized",
+                        "type": "bool"
+                    },
+                    {
+                        "name": "liquidity_net",
+                        "type": "i128"
+                    },
+                    {
+                        "name": "liquidity_gross",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_growth_outside_a",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_growth_outside_b",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "reward_growths_outside",
+                        "type": {
+                            "array": [
+                                "u128",
+                                3
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "TickArray",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "start_tick_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "ticks",
+                        "type": {
+                            "array": [
+                                {
+                                    "defined": {
+                                        "name": "Tick"
+                                    }
+                                },
+                                88
+                            ]
+                        }
+                    },
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "TokenBadge",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_mint",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "attribute_require_non_transferable_position",
+                        "type": "bool"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "TokenBadgeAttribute",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "RequireNonTransferablePosition",
+                        "fields": [
+                            "bool"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Traded",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "a_to_b",
+                        "type": "bool"
+                    },
+                    {
+                        "name": "pre_sqrt_price",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "post_sqrt_price",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "input_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "output_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "input_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "output_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "lp_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "protocol_fee",
+                        "type": "u64"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Whirlpool",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "whirlpool_bump",
+                        "type": {
+                            "array": [
+                                "u8",
+                                1
+                            ]
+                        }
+                    },
+                    {
+                        "name": "tick_spacing",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "fee_tier_index_seed",
+                        "type": {
+                            "array": [
+                                "u8",
+                                2
+                            ]
+                        }
+                    },
+                    {
+                        "name": "fee_rate",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "protocol_fee_rate",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "sqrt_price",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "tick_current_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "protocol_fee_owed_a",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "protocol_fee_owed_b",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_mint_a",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_vault_a",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "fee_growth_global_a",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "token_mint_b",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_vault_b",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "fee_growth_global_b",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "reward_last_updated_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "reward_infos",
+                        "type": {
+                            "array": [
+                                {
+                                    "defined": {
+                                        "name": "WhirlpoolRewardInfo"
+                                    }
+                                },
+                                3
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "WhirlpoolBumps",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool_bump",
+                        "type": "u8"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "WhirlpoolRewardInfo",
+            "docs": [
+                "Stores the state relevant for tracking liquidity mining rewards at the `Whirlpool` level.",
+                "These values are used in conjunction with `PositionRewardInfo`, `Tick.reward_growths_outside`,",
+                "and `Whirlpool.reward_last_updated_timestamp` to determine how many rewards are earned by open",
+                "positions."
+            ],
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "mint",
+                        "docs": [
+                            "Reward token mint."
+                        ],
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "vault",
+                        "docs": [
+                            "Reward vault token account."
+                        ],
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "extension",
+                        "docs": [
+                            "reward_infos[0]: Authority account that has permission to initialize the reward and set emissions.",
+                            "reward_infos[1]: used for a struct that contains fields for extending the functionality of Whirlpool.",
+                            "reward_infos[2]: reserved for future use.",
+                            "",
+                            "Historical notes:",
+                            "Originally, this was a field named \"authority\", but it was found that there was no opportunity",
+                            "to set different authorities for the three rewards. Therefore, the use of this field was changed for Whirlpool's future extensibility."
+                        ],
+                        "type": {
+                            "array": [
+                                "u8",
+                                32
+                            ]
+                        }
+                    },
+                    {
+                        "name": "emissions_per_second_x64",
+                        "docs": [
+                            "Q64.64 number that indicates how many tokens per second are earned per unit of liquidity."
+                        ],
+                        "type": "u128"
+                    },
+                    {
+                        "name": "growth_global_x64",
+                        "docs": [
+                            "Q64.64 number that tracks the total tokens earned per unit of liquidity since the reward",
+                            "emissions were turned on."
+                        ],
+                        "type": "u128"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "WhirlpoolsConfig",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "fee_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "collect_protocol_fees_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "reward_emissions_super_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "default_protocol_fee_rate",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "feature_flags",
+                        "type": "u16"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "WhirlpoolsConfigExtension",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "config_extension_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_badge_authority",
+                        "type": "pubkey"
+                    }
+                ]
+            }
+        }
+    ]
 }

--- a/idl/raydium_clmm.json
+++ b/idl/raydium_clmm.json
@@ -1,778 +1,170 @@
 {
-  "version": "0.1.0",
-  "name": "amm_v3",
+  "address": "CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK",
+  "metadata": {
+    "name": "raydium_clmm",
+    "version": "0.1.0",
+    "spec": "0.1.0",
+    "description": "Anchor client and source for Raydium concentrated liquidity AMM"
+  },
   "instructions": [
     {
-      "name": "createAmmConfig",
+      "name": "close_limit_order",
       "docs": [
-        "# Arguments",
-        "",
-        "* `ctx`- The accounts needed by instruction.",
-        "* `index` - The index of amm config, there may be multiple config.",
-        "* `tick_spacing` - The tickspacing binding with config, cannot be changed.",
-        "* `trade_fee_rate` - Trade fee rate, can be changed.",
-        "* `protocol_fee_rate` - The rate of protocol fee within tarde fee.",
-        "* `fund_fee_rate` - The rate of fund fee within tarde fee.",
-        ""
-      ],
-      "accounts": [
-        {
-          "name": "owner",
-          "isMut": true,
-          "isSigner": true,
-          "docs": [
-            "Address to be set as protocol owner."
-          ]
-        },
-        {
-          "name": "ammConfig",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Initialize config state account to store protocol owner address and fee rates."
-          ]
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "index",
-          "type": "u16"
-        },
-        {
-          "name": "tickSpacing",
-          "type": "u16"
-        },
-        {
-          "name": "tradeFeeRate",
-          "type": "u32"
-        },
-        {
-          "name": "protocolFeeRate",
-          "type": "u32"
-        },
-        {
-          "name": "fundFeeRate",
-          "type": "u32"
-        }
-      ]
-    },
-    {
-      "name": "updateAmmConfig",
-      "docs": [
-        "Updates the owner of the amm config",
-        "Must be called by the current owner or admin",
+        "Close a limit order",
+        "Closes the limit order account when unfilled amount is zero",
         "",
         "# Arguments",
         "",
-        "* `ctx`- The context of accounts",
-        "* `trade_fee_rate`- The new trade fee rate of amm config, be set when `param` is 0",
-        "* `protocol_fee_rate`- The new protocol fee rate of amm config, be set when `param` is 1",
-        "* `fund_fee_rate`- The new fund fee rate of amm config, be set when `param` is 2",
-        "* `new_owner`- The config's new owner, be set when `param` is 3",
-        "* `new_fund_owner`- The config's new fund owner, be set when `param` is 4",
-        "* `param`- The vaule can be 0 | 1 | 2 | 3 | 4, otherwise will report a error",
+        "* `ctx` - The context of accounts",
         ""
+      ],
+      "discriminator": [
+        76,
+        124,
+        128,
+        15,
+        213,
+        87,
+        37,
+        250
       ],
       "accounts": [
         {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": true,
-          "docs": [
-            "The amm config owner or admin"
-          ]
+          "name": "signer",
+          "signer": true
         },
         {
-          "name": "ammConfig",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Amm config account to be changed"
-          ]
-        }
-      ],
-      "args": [
-        {
-          "name": "param",
-          "type": "u8"
+          "name": "rent_receiver",
+          "writable": true
         },
         {
-          "name": "value",
-          "type": "u32"
-        }
-      ]
-    },
-    {
-      "name": "createPool",
-      "docs": [
-        "Creates a pool for the given token pair and the initial price",
-        "",
-        "# Arguments",
-        "",
-        "* `ctx`- The context of accounts",
-        "* `sqrt_price_x64` - the initial sqrt price (amount_token_1 / amount_token_0) of the pool as a Q64.64",
-        ""
-      ],
-      "accounts": [
-        {
-          "name": "poolCreator",
-          "isMut": true,
-          "isSigner": true,
-          "docs": [
-            "Address paying to create the pool. Can be anyone"
-          ]
-        },
-        {
-          "name": "ammConfig",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Which config the pool belongs to."
-          ]
-        },
-        {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Initialize an account to store the pool state"
-          ]
-        },
-        {
-          "name": "tokenMint0",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Token_0 mint, the key must be smaller then token_1 mint."
-          ]
-        },
-        {
-          "name": "tokenMint1",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Token_1 mint"
-          ]
-        },
-        {
-          "name": "tokenVault0",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Token_0 vault for the pool"
-          ]
-        },
-        {
-          "name": "tokenVault1",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Token_1 vault for the pool"
-          ]
-        },
-        {
-          "name": "observationState",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Initialize an account to store oracle observations"
-          ]
-        },
-        {
-          "name": "tickArrayBitmap",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Initialize an account to store if a tick array is initialized."
-          ]
-        },
-        {
-          "name": "tokenProgram0",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Spl token program or token program 2022"
-          ]
-        },
-        {
-          "name": "tokenProgram1",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Spl token program or token program 2022"
-          ]
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "To create a new program account"
-          ]
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Sysvar for program account"
-          ]
-        }
-      ],
-      "args": [
-        {
-          "name": "sqrtPriceX64",
-          "type": "u128"
-        },
-        {
-          "name": "openTime",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "updatePoolStatus",
-      "docs": [
-        "Update pool status for given vaule",
-        "",
-        "# Arguments",
-        "",
-        "* `ctx`- The context of accounts",
-        "* `status` - The vaule of status",
-        ""
-      ],
-      "accounts": [
-        {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "status",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "createOperationAccount",
-      "docs": [
-        "Creates an operation account for the program",
-        "",
-        "# Arguments",
-        "",
-        "* `ctx`- The context of accounts",
-        ""
-      ],
-      "accounts": [
-        {
-          "name": "owner",
-          "isMut": true,
-          "isSigner": true,
-          "docs": [
-            "Address to be set as operation account owner."
-          ]
-        },
-        {
-          "name": "operationState",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Initialize operation state account to store operation owner address and white list mint."
-          ]
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "limit_order",
+          "writable": true
         }
       ],
       "args": []
     },
     {
-      "name": "updateOperationAccount",
+      "name": "close_position",
       "docs": [
-        "Update the operation account",
+        "Close the user's position and NFT account. If the NFT mint belongs to token2022, it will also be closed and the funds returned to the NFT owner.",
         "",
         "# Arguments",
         "",
-        "* `ctx`- The context of accounts",
-        "* `param`- The vaule can be 0 | 1 | 2 | 3, otherwise will report a error",
-        "* `keys`- update operation owner when the `param` is 0",
-        "remove operation owner when the `param` is 1",
-        "update whitelist mint when the `param` is 2",
-        "remove whitelist mint when the `param` is 3",
+        "* `ctx` - The context of accounts",
         ""
+      ],
+      "discriminator": [
+        123,
+        134,
+        81,
+        0,
+        49,
+        68,
+        98,
+        98
       ],
       "accounts": [
         {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": true,
+          "name": "nft_owner",
           "docs": [
-            "Address to be set as operation account owner."
-          ]
+            "The position nft owner"
+          ],
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "operationState",
-          "isMut": true,
-          "isSigner": false,
+          "name": "position_nft_mint",
           "docs": [
-            "Initialize operation state account to store operation owner address and white list mint."
-          ]
+            "Mint address bound to the personal position."
+          ],
+          "writable": true
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "param",
-          "type": "u8"
+          "name": "position_nft_account",
+          "docs": [
+            "User token account where position NFT be minted to"
+          ],
+          "writable": true
         },
         {
-          "name": "keys",
-          "type": {
-            "vec": "publicKey"
+          "name": "personal_position",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "position_nft_mint"
+              }
+            ]
           }
-        }
-      ]
-    },
-    {
-      "name": "transferRewardOwner",
-      "docs": [
-        "Transfer reward owner",
-        "",
-        "# Arguments",
-        "",
-        "* `ctx`- The context of accounts",
-        "* `new_owner`- new owner pubkey",
-        ""
-      ],
-      "accounts": [
+        },
         {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": true,
+          "name": "system_program",
           "docs": [
-            "Address to be set as operation account owner."
-          ]
+            "System program to close the position state account"
+          ],
+          "address": "11111111111111111111111111111111"
         },
         {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "newOwner",
-          "type": "publicKey"
-        }
-      ]
-    },
-    {
-      "name": "initializeReward",
-      "docs": [
-        "Initialize a reward info for a given pool and reward index",
-        "",
-        "# Arguments",
-        "",
-        "* `ctx`- The context of accounts",
-        "* `reward_index` - the index to reward info",
-        "* `open_time` - reward open timestamp",
-        "* `end_time` - reward end timestamp",
-        "* `emissions_per_second_x64` - Token reward per second are earned per unit of liquidity.",
-        ""
-      ],
-      "accounts": [
-        {
-          "name": "rewardFunder",
-          "isMut": true,
-          "isSigner": true,
+          "name": "token_program",
           "docs": [
-            "The founder deposit reward token to vault"
-          ]
-        },
-        {
-          "name": "funderTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "ammConfig",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "For check the reward_funder authority"
-          ]
-        },
-        {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Set reward for this pool"
-          ]
-        },
-        {
-          "name": "operationState",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "load info from the account to judge reward permission"
-          ]
-        },
-        {
-          "name": "rewardTokenMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Reward mint"
-          ]
-        },
-        {
-          "name": "rewardTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "A pda, reward vault"
-          ]
-        },
-        {
-          "name": "rewardTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "param",
-          "type": {
-            "defined": "InitializeRewardParam"
-          }
-        }
-      ]
-    },
-    {
-      "name": "collectRemainingRewards",
-      "docs": [
-        "Collect remaining reward token for reward founder",
-        "",
-        "# Arguments",
-        "",
-        "* `ctx`- The context of accounts",
-        "* `reward_index` - the index to reward info",
-        ""
-      ],
-      "accounts": [
-        {
-          "name": "rewardFunder",
-          "isMut": false,
-          "isSigner": true,
-          "docs": [
-            "The founder who init reward info in berfore"
-          ]
-        },
-        {
-          "name": "funderTokenAccount",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "The funder's reward token account"
-          ]
-        },
-        {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Set reward for this pool"
-          ]
-        },
-        {
-          "name": "rewardTokenVault",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Reward vault transfer remaining token to founder token account"
-          ]
-        },
-        {
-          "name": "rewardVaultMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "The mint of reward token vault"
-          ]
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram2022",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Token program 2022"
-          ]
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "memo program"
-          ]
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "updateRewardInfos",
-      "docs": [
-        "Update rewards info of the given pool, can be called for everyone",
-        "",
-        "# Arguments",
-        "",
-        "* `ctx`- The context of accounts",
-        ""
-      ],
-      "accounts": [
-        {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "The liquidity pool for which reward info to update"
+            "Token/Token2022 program to close token/mint account"
           ]
         }
       ],
       "args": []
     },
     {
-      "name": "setRewardParams",
+      "name": "close_protocol_position",
       "docs": [
-        "Restset reward param, start a new reward cycle or extend the current cycle.",
+        "The CLMM protocol decides to discard the protocol position account, which can reduce users' opening costs.",
+        "After the original protocol position account is closed, the gas fee will be refunded to the user who created it.",
         "",
         "# Arguments",
         "",
         "* `ctx` - The context of accounts",
-        "* `reward_index` - The index of reward token in the pool.",
-        "* `emissions_per_second_x64` - The per second emission reward, when extend the current cycle,",
-        "new value can't be less than old value",
-        "* `open_time` - reward open timestamp, must be set when state a new cycle",
-        "* `end_time` - reward end timestamp",
         ""
+      ],
+      "discriminator": [
+        201,
+        117,
+        152,
+        144,
+        85,
+        85,
+        108,
+        178
       ],
       "accounts": [
         {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": true,
-          "docs": [
-            "Address to be set as protocol owner. It pays to create factory state account."
-          ]
+          "name": "admin",
+          "writable": true,
+          "signer": true,
+          "address": "2kqJncUWCkk5TyJYamPW5DECfqAz4brYpH6r5j6vg9yx"
         },
         {
-          "name": "ammConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "operationState",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "load info from the account to judge reward permission"
-          ]
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Token program"
-          ]
-        },
-        {
-          "name": "tokenProgram2022",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Token program 2022"
-          ]
+          "name": "protocol_position",
+          "writable": true
         }
       ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        },
-        {
-          "name": "emissionsPerSecondX64",
-          "type": "u128"
-        },
-        {
-          "name": "openTime",
-          "type": "u64"
-        },
-        {
-          "name": "endTime",
-          "type": "u64"
-        }
-      ]
+      "args": []
     },
     {
-      "name": "collectProtocolFee",
-      "docs": [
-        "Collect the protocol fee accrued to the pool",
-        "",
-        "# Arguments",
-        "",
-        "* `ctx` - The context of accounts",
-        "* `amount_0_requested` - The maximum amount of token_0 to send, can be 0 to collect fees in only token_1",
-        "* `amount_1_requested` - The maximum amount of token_1 to send, can be 0 to collect fees in only token_0",
-        ""
-      ],
-      "accounts": [
-        {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": true,
-          "docs": [
-            "Only admin or config owner can collect fee now"
-          ]
-        },
-        {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Pool state stores accumulated protocol fee amount"
-          ]
-        },
-        {
-          "name": "ammConfig",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Amm config account stores owner"
-          ]
-        },
-        {
-          "name": "tokenVault0",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "The address that holds pool tokens for token_0"
-          ]
-        },
-        {
-          "name": "tokenVault1",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "The address that holds pool tokens for token_1"
-          ]
-        },
-        {
-          "name": "vault0Mint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "The mint of token vault 0"
-          ]
-        },
-        {
-          "name": "vault1Mint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "The mint of token vault 1"
-          ]
-        },
-        {
-          "name": "recipientTokenAccount0",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "The address that receives the collected token_0 protocol fees"
-          ]
-        },
-        {
-          "name": "recipientTokenAccount1",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "The address that receives the collected token_1 protocol fees"
-          ]
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "The SPL program to perform token transfers"
-          ]
-        },
-        {
-          "name": "tokenProgram2022",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "The SPL program 2022 to perform token transfers"
-          ]
-        }
-      ],
-      "args": [
-        {
-          "name": "amount0Requested",
-          "type": "u64"
-        },
-        {
-          "name": "amount1Requested",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "collectFundFee",
+      "name": "collect_fund_fee",
       "docs": [
         "Collect the fund fee accrued to the pool",
         "",
@@ -783,806 +175,1587 @@
         "* `amount_1_requested` - The maximum amount of token_1 to send, can be 0 to collect fees in only token_0",
         ""
       ],
+      "discriminator": [
+        167,
+        138,
+        78,
+        149,
+        223,
+        194,
+        6,
+        126
+      ],
       "accounts": [
         {
           "name": "owner",
-          "isMut": false,
-          "isSigner": true,
           "docs": [
             "Only admin or fund_owner can collect fee now"
-          ]
+          ],
+          "signer": true
         },
         {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false,
+          "name": "pool_state",
           "docs": [
             "Pool state stores accumulated protocol fee amount"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "ammConfig",
-          "isMut": false,
-          "isSigner": false,
+          "name": "amm_config",
           "docs": [
             "Amm config account stores fund_owner"
           ]
         },
         {
-          "name": "tokenVault0",
-          "isMut": true,
-          "isSigner": false,
+          "name": "token_vault_0",
           "docs": [
             "The address that holds pool tokens for token_0"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "tokenVault1",
-          "isMut": true,
-          "isSigner": false,
+          "name": "token_vault_1",
           "docs": [
             "The address that holds pool tokens for token_1"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "vault0Mint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_0_mint",
           "docs": [
             "The mint of token vault 0"
           ]
         },
         {
-          "name": "vault1Mint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_1_mint",
           "docs": [
             "The mint of token vault 1"
           ]
         },
         {
-          "name": "recipientTokenAccount0",
-          "isMut": true,
-          "isSigner": false,
+          "name": "recipient_token_account_0",
           "docs": [
             "The address that receives the collected token_0 protocol fees"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "recipientTokenAccount1",
-          "isMut": true,
-          "isSigner": false,
+          "name": "recipient_token_account_1",
           "docs": [
             "The address that receives the collected token_1 protocol fees"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_program",
           "docs": [
             "The SPL program to perform token transfers"
-          ]
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
         {
-          "name": "tokenProgram2022",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_program_2022",
           "docs": [
             "The SPL program 2022 to perform token transfers"
-          ]
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
         }
       ],
       "args": [
         {
-          "name": "amount0Requested",
+          "name": "amount_0_requested",
           "type": "u64"
         },
         {
-          "name": "amount1Requested",
+          "name": "amount_1_requested",
           "type": "u64"
         }
       ]
     },
     {
-      "name": "openPosition",
+      "name": "collect_protocol_fee",
       "docs": [
-        "#[deprecated(note = \"Use `open_position_with_token22_nft` instead.\")]",
-        "Creates a new position wrapped in a NFT",
+        "Collect the protocol fee accrued to the pool",
         "",
         "# Arguments",
         "",
         "* `ctx` - The context of accounts",
-        "* `tick_lower_index` - The low boundary of market",
-        "* `tick_upper_index` - The upper boundary of market",
-        "* `tick_array_lower_start_index` - The start index of tick array which include tick low",
-        "* `tick_array_upper_start_index` - The start index of tick array which include tick upper",
-        "* `liquidity` - The liquidity to be added",
-        "* `amount_0_max` - The max amount of token_0 to spend, which serves as a slippage check",
-        "* `amount_1_max` - The max amount of token_1 to spend, which serves as a slippage check",
+        "* `amount_0_requested` - The maximum amount of token_0 to send, can be 0 to collect fees in only token_1",
+        "* `amount_1_requested` - The maximum amount of token_1 to send, can be 0 to collect fees in only token_0",
         ""
+      ],
+      "discriminator": [
+        136,
+        136,
+        252,
+        221,
+        194,
+        66,
+        126,
+        89
       ],
       "accounts": [
         {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true,
+          "name": "owner",
           "docs": [
-            "Pays to mint the position"
+            "Only admin or config owner can collect fee now"
+          ],
+          "signer": true
+        },
+        {
+          "name": "pool_state",
+          "docs": [
+            "Pool state stores accumulated protocol fee amount"
+          ],
+          "writable": true
+        },
+        {
+          "name": "amm_config",
+          "docs": [
+            "Amm config account stores owner"
           ]
         },
         {
-          "name": "positionNftOwner",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionNftMint",
-          "isMut": true,
-          "isSigner": true,
-          "docs": [
-            "Unique token mint address"
-          ]
-        },
-        {
-          "name": "positionNftAccount",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Token account where position NFT will be minted",
-            "This account created in the contract by cpi to avoid large stack variables"
-          ]
-        },
-        {
-          "name": "metadataAccount",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "To store metaplex metadata"
-          ]
-        },
-        {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Add liquidity for this pool"
-          ]
-        },
-        {
-          "name": "protocolPosition",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Store the information of market marking in range"
-          ]
-        },
-        {
-          "name": "tickArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "personalPosition",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "personal position state"
-          ]
-        },
-        {
-          "name": "tokenAccount0",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "The token_0 account deposit token to the pool"
-          ]
-        },
-        {
-          "name": "tokenAccount1",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "The token_1 account deposit token to the pool"
-          ]
-        },
-        {
-          "name": "tokenVault0",
-          "isMut": true,
-          "isSigner": false,
+          "name": "token_vault_0",
           "docs": [
             "The address that holds pool tokens for token_0"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "tokenVault1",
-          "isMut": true,
-          "isSigner": false,
+          "name": "token_vault_1",
           "docs": [
             "The address that holds pool tokens for token_1"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Sysvar for token mint and ATA creation"
-          ]
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Program to create the position manager state account"
-          ]
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Program to create mint account and mint tokens"
-          ]
-        },
-        {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Program to create an ATA for receiving position NFT"
-          ]
-        },
-        {
-          "name": "metadataProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Program to create NFT metadata"
-          ]
-        }
-      ],
-      "args": [
-        {
-          "name": "tickLowerIndex",
-          "type": "i32"
-        },
-        {
-          "name": "tickUpperIndex",
-          "type": "i32"
-        },
-        {
-          "name": "tickArrayLowerStartIndex",
-          "type": "i32"
-        },
-        {
-          "name": "tickArrayUpperStartIndex",
-          "type": "i32"
-        },
-        {
-          "name": "liquidity",
-          "type": "u128"
-        },
-        {
-          "name": "amount0Max",
-          "type": "u64"
-        },
-        {
-          "name": "amount1Max",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "openPositionV2",
-      "docs": [
-        "#[deprecated(note = \"Use `open_position_with_token22_nft` instead.\")]",
-        "Creates a new position wrapped in a NFT, support Token2022",
-        "",
-        "# Arguments",
-        "",
-        "* `ctx` - The context of accounts",
-        "* `tick_lower_index` - The low boundary of market",
-        "* `tick_upper_index` - The upper boundary of market",
-        "* `tick_array_lower_start_index` - The start index of tick array which include tick low",
-        "* `tick_array_upper_start_index` - The start index of tick array which include tick upper",
-        "* `liquidity` - The liquidity to be added, if zero, and the base_flage is specified, calculate liquidity base amount_0_max or amount_1_max according base_flag, otherwise open position with zero liquidity",
-        "* `amount_0_max` - The max amount of token_0 to spend, which serves as a slippage check",
-        "* `amount_1_max` - The max amount of token_1 to spend, which serves as a slippage check",
-        "* `with_metadata` - The flag indicating whether to create NFT mint metadata",
-        "* `base_flag` - if the liquidity specified as zero, true: calculate liquidity base amount_0_max otherwise base amount_1_max",
-        ""
-      ],
-      "accounts": [
-        {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true,
-          "docs": [
-            "Pays to mint the position"
-          ]
-        },
-        {
-          "name": "positionNftOwner",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionNftMint",
-          "isMut": true,
-          "isSigner": true,
-          "docs": [
-            "Unique token mint address"
-          ]
-        },
-        {
-          "name": "positionNftAccount",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Token account where position NFT will be minted"
-          ]
-        },
-        {
-          "name": "metadataAccount",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "To store metaplex metadata"
-          ]
-        },
-        {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Add liquidity for this pool"
-          ]
-        },
-        {
-          "name": "protocolPosition",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Store the information of market marking in range"
-          ]
-        },
-        {
-          "name": "tickArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "personalPosition",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "personal position state"
-          ]
-        },
-        {
-          "name": "tokenAccount0",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "The token_0 account deposit token to the pool"
-          ]
-        },
-        {
-          "name": "tokenAccount1",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "The token_1 account deposit token to the pool"
-          ]
-        },
-        {
-          "name": "tokenVault0",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "The address that holds pool tokens for token_0"
-          ]
-        },
-        {
-          "name": "tokenVault1",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "The address that holds pool tokens for token_1"
-          ]
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Sysvar for token mint and ATA creation"
-          ]
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Program to create the position manager state account"
-          ]
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Program to create mint account and mint tokens"
-          ]
-        },
-        {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Program to create an ATA for receiving position NFT"
-          ]
-        },
-        {
-          "name": "metadataProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Program to create NFT metadata"
-          ]
-        },
-        {
-          "name": "tokenProgram2022",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Program to create mint account and mint tokens"
-          ]
-        },
-        {
-          "name": "vault0Mint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_0_mint",
           "docs": [
             "The mint of token vault 0"
           ]
         },
         {
-          "name": "vault1Mint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_1_mint",
           "docs": [
             "The mint of token vault 1"
           ]
+        },
+        {
+          "name": "recipient_token_account_0",
+          "docs": [
+            "The address that receives the collected token_0 protocol fees"
+          ],
+          "writable": true
+        },
+        {
+          "name": "recipient_token_account_1",
+          "docs": [
+            "The address that receives the collected token_1 protocol fees"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "The SPL program to perform token transfers"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_program_2022",
+          "docs": [
+            "The SPL program 2022 to perform token transfers"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
         }
       ],
       "args": [
         {
-          "name": "tickLowerIndex",
-          "type": "i32"
-        },
-        {
-          "name": "tickUpperIndex",
-          "type": "i32"
-        },
-        {
-          "name": "tickArrayLowerStartIndex",
-          "type": "i32"
-        },
-        {
-          "name": "tickArrayUpperStartIndex",
-          "type": "i32"
-        },
-        {
-          "name": "liquidity",
-          "type": "u128"
-        },
-        {
-          "name": "amount0Max",
+          "name": "amount_0_requested",
           "type": "u64"
         },
         {
-          "name": "amount1Max",
+          "name": "amount_1_requested",
           "type": "u64"
-        },
-        {
-          "name": "withMetadata",
-          "type": "bool"
-        },
-        {
-          "name": "baseFlag",
-          "type": {
-            "option": "bool"
-          }
         }
       ]
     },
     {
-      "name": "openPositionWithToken22Nft",
+      "name": "collect_remaining_rewards",
       "docs": [
-        "Creates a new position wrapped in a Token2022 NFT without relying on metadata_program and metadata_account, reduce the cost for user to create a personal position.",
+        "Collect remaining reward token for reward founder",
         "",
         "# Arguments",
         "",
         "* `ctx` - The context of accounts",
-        "* `tick_lower_index` - The low boundary of market",
-        "* `tick_upper_index` - The upper boundary of market",
-        "* `tick_array_lower_start_index` - The start index of tick array which include tick low",
-        "* `tick_array_upper_start_index` - The start index of tick array which include tick upper",
-        "* `liquidity` - The liquidity to be added, if zero, and the base_flage is specified, calculate liquidity base amount_0_max or amount_1_max according base_flag, otherwise open position with zero liquidity",
-        "* `amount_0_max` - The max amount of token_0 to spend, which serves as a slippage check",
-        "* `amount_1_max` - The max amount of token_1 to spend, which serves as a slippage check",
-        "* `with_metadata` - The flag indicating whether to create NFT mint metadata",
-        "* `base_flag` - if the liquidity specified as zero, true: calculate liquidity base amount_0_max otherwise base amount_1_max",
+        "* `reward_index` - the index to reward info",
         ""
+      ],
+      "discriminator": [
+        18,
+        237,
+        166,
+        197,
+        34,
+        16,
+        213,
+        144
       ],
       "accounts": [
         {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true,
+          "name": "reward_funder",
           "docs": [
-            "Pays to mint the position"
+            "The founder who init reward info previously"
+          ],
+          "signer": true
+        },
+        {
+          "name": "funder_token_account",
+          "docs": [
+            "The funder's reward token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "pool_state",
+          "docs": [
+            "Set reward for this pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "reward_token_vault",
+          "docs": [
+            "Reward vault transfer remaining token to founder token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "reward_vault_mint",
+          "docs": [
+            "The mint of reward token vault"
           ]
         },
         {
-          "name": "positionNftOwner",
-          "isMut": false,
-          "isSigner": false
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
         {
-          "name": "positionNftMint",
-          "isMut": true,
-          "isSigner": true,
+          "name": "token_program_2022",
           "docs": [
-            "Unique token mint address, initialize in constract"
+            "Token program 2022"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "memo_program",
+          "docs": [
+            "memo program"
+          ],
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "create_amm_config",
+      "docs": [
+        "# Arguments",
+        "",
+        "* `ctx` - The accounts needed by instruction.",
+        "* `index` - The index of amm config, there may be multiple config.",
+        "* `tick_spacing` - The tickspacing binding with config, cannot be changed.",
+        "* `trade_fee_rate` - Trade fee rate, can be changed.",
+        "* `protocol_fee_rate` - The rate of protocol fee within trade fee.",
+        "* `fund_fee_rate` - The rate of fund fee within trade fee.",
+        "* `limit_fee_rate` - The rate of limit order fee.",
+        ""
+      ],
+      "discriminator": [
+        137,
+        52,
+        237,
+        212,
+        215,
+        117,
+        108,
+        104
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "docs": [
+            "Address to be set as protocol owner."
+          ],
+          "writable": true,
+          "signer": true,
+          "address": "2kqJncUWCkk5TyJYamPW5DECfqAz4brYpH6r5j6vg9yx"
+        },
+        {
+          "name": "amm_config",
+          "docs": [
+            "Initialize config state account to store protocol owner address and fee rates."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  109,
+                  109,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "index"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "index",
+          "type": "u16"
+        },
+        {
+          "name": "tick_spacing",
+          "type": "u16"
+        },
+        {
+          "name": "trade_fee_rate",
+          "type": "u32"
+        },
+        {
+          "name": "protocol_fee_rate",
+          "type": "u32"
+        },
+        {
+          "name": "fund_fee_rate",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "create_customizable_pool",
+      "docs": [
+        "Creates a pool for the given token pair with customizable parameters",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `customizable_params` - the customizable parameters",
+        ""
+      ],
+      "discriminator": [
+        43,
+        68,
+        212,
+        167,
+        89,
+        47,
+        164,
+        1
+      ],
+      "accounts": [
+        {
+          "name": "pool_creator",
+          "docs": [
+            "Address paying to create the pool"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "amm_config",
+          "docs": [
+            "Which config the pool belongs to."
           ]
         },
         {
-          "name": "positionNftAccount",
-          "isMut": true,
-          "isSigner": false
+          "name": "pool_state",
+          "docs": [
+            "Initialize an account to store the pool state"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "amm_config"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_0"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_1"
+              }
+            ]
+          }
         },
         {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false,
+          "name": "token_mint_0",
           "docs": [
-            "Add liquidity for this pool"
+            "Token_0 mint, the key must be smaller then token_1 mint."
           ]
         },
         {
-          "name": "protocolPosition",
-          "isMut": true,
-          "isSigner": false,
+          "name": "token_mint_1",
           "docs": [
-            "Store the information of market marking in range"
+            "Token_1 mint"
           ]
         },
         {
-          "name": "tickArrayLower",
-          "isMut": true,
-          "isSigner": false
+          "name": "token_vault_0",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_0"
+              }
+            ]
+          }
         },
         {
-          "name": "tickArrayUpper",
-          "isMut": true,
-          "isSigner": false
+          "name": "token_vault_1",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_1"
+              }
+            ]
+          }
         },
         {
-          "name": "personalPosition",
-          "isMut": true,
-          "isSigner": false,
+          "name": "observation_state",
           "docs": [
-            "personal position state"
+            "Initialize an account to store oracle observations"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  98,
+                  115,
+                  101,
+                  114,
+                  118,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              }
+            ]
+          }
+        },
+        {
+          "name": "tick_array_bitmap",
+          "docs": [
+            "Initialize an account to store if a tick array is initialized."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  116,
+                  105,
+                  99,
+                  107,
+                  95,
+                  97,
+                  114,
+                  114,
+                  97,
+                  121,
+                  95,
+                  98,
+                  105,
+                  116,
+                  109,
+                  97,
+                  112,
+                  95,
+                  101,
+                  120,
+                  116,
+                  101,
+                  110,
+                  115,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program_0",
+          "docs": [
+            "Spl token program or token program 2022"
           ]
         },
         {
-          "name": "tokenAccount0",
-          "isMut": true,
-          "isSigner": false,
+          "name": "token_program_1",
           "docs": [
-            "The token_0 account deposit token to the pool"
+            "Spl token program or token program 2022"
           ]
         },
         {
-          "name": "tokenAccount1",
-          "isMut": true,
-          "isSigner": false,
+          "name": "system_program",
           "docs": [
-            "The token_1 account deposit token to the pool"
-          ]
-        },
-        {
-          "name": "tokenVault0",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "The address that holds pool tokens for token_0"
-          ]
-        },
-        {
-          "name": "tokenVault1",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "The address that holds pool tokens for token_1"
-          ]
+            "To create a new program account"
+          ],
+          "address": "11111111111111111111111111111111"
         },
         {
           "name": "rent",
-          "isMut": false,
-          "isSigner": false,
           "docs": [
-            "Sysvar for token mint and ATA creation"
-          ]
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Program to create the position manager state account"
-          ]
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Program to transfer for token account"
-          ]
-        },
-        {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Program to create an ATA for receiving position NFT"
-          ]
-        },
-        {
-          "name": "tokenProgram2022",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Program to create NFT mint/token account and transfer for token22 account"
-          ]
-        },
-        {
-          "name": "vault0Mint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "The mint of token vault 0"
-          ]
-        },
-        {
-          "name": "vault1Mint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "The mint of token vault 1"
-          ]
+            "Sysvar for program account"
+          ],
+          "address": "SysvarRent111111111111111111111111111111111"
         }
       ],
       "args": [
         {
-          "name": "tickLowerIndex",
-          "type": "i32"
-        },
-        {
-          "name": "tickUpperIndex",
-          "type": "i32"
-        },
-        {
-          "name": "tickArrayLowerStartIndex",
-          "type": "i32"
-        },
-        {
-          "name": "tickArrayUpperStartIndex",
-          "type": "i32"
-        },
-        {
-          "name": "liquidity",
-          "type": "u128"
-        },
-        {
-          "name": "amount0Max",
-          "type": "u64"
-        },
-        {
-          "name": "amount1Max",
-          "type": "u64"
-        },
-        {
-          "name": "withMetadata",
-          "type": "bool"
-        },
-        {
-          "name": "baseFlag",
+          "name": "customizable_params",
           "type": {
-            "option": "bool"
+            "defined": {
+              "name": "CreateCustomizableParams"
+            }
           }
         }
       ]
     },
     {
-      "name": "closePosition",
+      "name": "create_dynamic_fee_config",
       "docs": [
-        "Close the user's position and NFT account. If the NFT mint belongs to token2022, it will also be closed and the funds returned to the NFT owner.",
+        "Create dynamic fee config",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `index` - The index of dynamic fee config",
+        "* `filter_period` - The period of filter",
+        "* `decay_period` - The period of decay",
+        "* `reduction_factor` - The reduction factor",
+        "* `adaptive_fee_control_factor` - The adaptive fee control factor",
+        "* `max_volatility_accumulator` - The max volatility accumulator",
+        "* `tick_group_size` - The tick group size"
+      ],
+      "discriminator": [
+        189,
+        14,
+        181,
+        120,
+        85,
+        118,
+        227,
+        62
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "writable": true,
+          "signer": true,
+          "address": "2kqJncUWCkk5TyJYamPW5DECfqAz4brYpH6r5j6vg9yx"
+        },
+        {
+          "name": "dynamic_fee_config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  121,
+                  110,
+                  97,
+                  109,
+                  105,
+                  99,
+                  95,
+                  102,
+                  101,
+                  101,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "index"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "index",
+          "type": "u16"
+        },
+        {
+          "name": "filter_period",
+          "type": "u16"
+        },
+        {
+          "name": "decay_period",
+          "type": "u16"
+        },
+        {
+          "name": "reduction_factor",
+          "type": "u16"
+        },
+        {
+          "name": "dynamic_fee_control",
+          "type": "u32"
+        },
+        {
+          "name": "max_volatility_accumulator",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "create_operation_account",
+      "docs": [
+        "Creates an operation account for the program",
         "",
         "# Arguments",
         "",
         "* `ctx` - The context of accounts",
         ""
       ],
+      "discriminator": [
+        63,
+        87,
+        148,
+        33,
+        109,
+        35,
+        8,
+        104
+      ],
       "accounts": [
         {
-          "name": "nftOwner",
-          "isMut": true,
-          "isSigner": true,
+          "name": "owner",
           "docs": [
-            "The position nft owner"
-          ]
+            "Address to be set as operation account owner."
+          ],
+          "writable": true,
+          "signer": true,
+          "address": "2kqJncUWCkk5TyJYamPW5DECfqAz4brYpH6r5j6vg9yx"
         },
         {
-          "name": "positionNftMint",
-          "isMut": true,
-          "isSigner": false,
+          "name": "operation_state",
           "docs": [
-            "Mint address bound to the personal position."
-          ]
+            "Initialize operation state account to store operation owner address and white list mint."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  112,
+                  101,
+                  114,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              }
+            ]
+          }
         },
         {
-          "name": "positionNftAccount",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "User token account where position NFT be minted to"
-          ]
-        },
-        {
-          "name": "personalPosition",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "System program to close the position state account"
-          ]
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Token/Token2022 program to close token/mint account"
-          ]
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         }
       ],
       "args": []
     },
     {
-      "name": "increaseLiquidity",
+      "name": "create_pool",
+      "docs": [
+        "Creates a pool for the given token pair and the initial price",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `sqrt_price_x64` - the initial sqrt price (amount_token_1 / amount_token_0) of the pool as a Q64.64",
+        "Note: The open_time must be smaller than the current block_timestamp on chain."
+      ],
+      "discriminator": [
+        233,
+        146,
+        209,
+        142,
+        207,
+        104,
+        64,
+        188
+      ],
+      "accounts": [
+        {
+          "name": "pool_creator",
+          "docs": [
+            "Address paying to create the pool. Can be anyone"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "amm_config",
+          "docs": [
+            "Which config the pool belongs to."
+          ]
+        },
+        {
+          "name": "pool_state",
+          "docs": [
+            "Initialize an account to store the pool state"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "amm_config"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_0"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_1"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_mint_0",
+          "docs": [
+            "Token_0 mint, the key must be smaller then token_1 mint."
+          ]
+        },
+        {
+          "name": "token_mint_1",
+          "docs": [
+            "Token_1 mint"
+          ]
+        },
+        {
+          "name": "token_vault_0",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_0"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_vault_1",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_1"
+              }
+            ]
+          }
+        },
+        {
+          "name": "observation_state",
+          "docs": [
+            "Initialize an account to store oracle observations"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  98,
+                  115,
+                  101,
+                  114,
+                  118,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              }
+            ]
+          }
+        },
+        {
+          "name": "tick_array_bitmap",
+          "docs": [
+            "Initialize an account to store if a tick array is initialized."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  116,
+                  105,
+                  99,
+                  107,
+                  95,
+                  97,
+                  114,
+                  114,
+                  97,
+                  121,
+                  95,
+                  98,
+                  105,
+                  116,
+                  109,
+                  97,
+                  112,
+                  95,
+                  101,
+                  120,
+                  116,
+                  101,
+                  110,
+                  115,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program_0",
+          "docs": [
+            "Spl token program or token program 2022"
+          ]
+        },
+        {
+          "name": "token_program_1",
+          "docs": [
+            "Spl token program or token program 2022"
+          ]
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "To create a new program account"
+          ],
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "rent",
+          "docs": [
+            "Sysvar for program account"
+          ],
+          "address": "SysvarRent111111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "sqrt_price_x64",
+          "type": "u128"
+        },
+        {
+          "name": "open_time",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "create_support_mint_associated",
+      "docs": [
+        "Create support token22 mint account which can create pool and send rewards while ignoring unsupported extensions."
+      ],
+      "discriminator": [
+        17,
+        251,
+        65,
+        92,
+        136,
+        242,
+        14,
+        169
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "docs": [
+            "Address to be set as protocol owner."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_mint",
+          "docs": [
+            "Support token mint"
+          ]
+        },
+        {
+          "name": "support_mint_associated",
+          "docs": [
+            "Initialize support mint state account to store support mint address and bump."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  117,
+                  112,
+                  112,
+                  111,
+                  114,
+                  116,
+                  95,
+                  109,
+                  105,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "decrease_limit_order",
+      "docs": [
+        "Decrease/Cancel a limit order",
+        "First settle the filled portion of the order; only the remaining unfilled amount can be decreased.",
+        "Even if the specified amount is very large, the decrease will not exceed the remaining unfilled order amount.",
+        "It is recommended to call the `settle_limit_order` instruction before invoking this instruction to settle any filled portions of the order.",
+        "Make sure to check your order's remaining unfilled amount.",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `amount` - The decrease amount of the order,",
+        "* `amount_min` - The minimum amount of the order, which serves as a slippage check",
+        ""
+      ],
+      "discriminator": [
+        117,
+        157,
+        60,
+        103,
+        66,
+        49,
+        163,
+        0
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "signer": true
+        },
+        {
+          "name": "pool_state",
+          "writable": true
+        },
+        {
+          "name": "tick_array",
+          "writable": true
+        },
+        {
+          "name": "limit_order",
+          "writable": true
+        },
+        {
+          "name": "input_token_account",
+          "docs": [
+            "The payer's limit order token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "output_token_account",
+          "docs": [
+            "The owner's output token account (opposite direction from input)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "input_vault",
+          "docs": [
+            "The address that holds limit order token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "output_vault",
+          "docs": [
+            "The address that holds output tokens"
+          ],
+          "writable": true
+        },
+        {
+          "name": "input_vault_mint",
+          "docs": [
+            "The mint of token vault"
+          ]
+        },
+        {
+          "name": "output_vault_mint",
+          "docs": [
+            "The mint of output vault"
+          ]
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL program for token transfers"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_program_2022",
+          "docs": [
+            "SPL program 2022 for token transfers"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "amount_min",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "decrease_liquidity",
+      "docs": [
+        "#[deprecated(note = \"Use `decrease_liquidity_v2` instead.\")]",
+        "Decreases liquidity for an existing position",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` -  The context of accounts",
+        "* `liquidity` - The amount by which liquidity will be decreased",
+        "* `amount_0_min` - The minimum amount of token_0 that should be accounted for the burned liquidity",
+        "* `amount_1_min` - The minimum amount of token_1 that should be accounted for the burned liquidity",
+        ""
+      ],
+      "discriminator": [
+        160,
+        38,
+        208,
+        111,
+        104,
+        91,
+        44,
+        1
+      ],
+      "accounts": [
+        {
+          "name": "nft_owner",
+          "docs": [
+            "The position owner or delegated authority"
+          ],
+          "signer": true
+        },
+        {
+          "name": "nft_account",
+          "docs": [
+            "The token account for the tokenized position"
+          ]
+        },
+        {
+          "name": "personal_position",
+          "docs": [
+            "Decrease liquidity for this position"
+          ],
+          "writable": true
+        },
+        {
+          "name": "pool_state",
+          "writable": true
+        },
+        {
+          "name": "protocol_position"
+        },
+        {
+          "name": "token_vault_0",
+          "docs": [
+            "Token_0 vault"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_vault_1",
+          "docs": [
+            "Token_1 vault"
+          ],
+          "writable": true
+        },
+        {
+          "name": "tick_array_lower",
+          "docs": [
+            "Stores init state for the lower tick"
+          ],
+          "writable": true
+        },
+        {
+          "name": "tick_array_upper",
+          "docs": [
+            "Stores init state for the upper tick"
+          ],
+          "writable": true
+        },
+        {
+          "name": "recipient_token_account_0",
+          "docs": [
+            "The destination token account for receive amount_0"
+          ],
+          "writable": true
+        },
+        {
+          "name": "recipient_token_account_1",
+          "docs": [
+            "The destination token account for receive amount_1"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL program to transfer out tokens"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity",
+          "type": "u128"
+        },
+        {
+          "name": "amount_0_min",
+          "type": "u64"
+        },
+        {
+          "name": "amount_1_min",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "decrease_liquidity_v2",
+      "docs": [
+        "Decreases liquidity for an existing position, support Token2022",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` -  The context of accounts",
+        "* `liquidity` - The amount by which liquidity will be decreased",
+        "* `amount_0_min` - The minimum amount of token_0 that should be accounted for the burned liquidity",
+        "* `amount_1_min` - The minimum amount of token_1 that should be accounted for the burned liquidity",
+        ""
+      ],
+      "discriminator": [
+        58,
+        127,
+        188,
+        62,
+        79,
+        82,
+        196,
+        96
+      ],
+      "accounts": [
+        {
+          "name": "nft_owner",
+          "docs": [
+            "The position owner or delegated authority"
+          ],
+          "signer": true
+        },
+        {
+          "name": "nft_account",
+          "docs": [
+            "The token account for the tokenized position"
+          ]
+        },
+        {
+          "name": "personal_position",
+          "docs": [
+            "Decrease liquidity for this position"
+          ],
+          "writable": true
+        },
+        {
+          "name": "pool_state",
+          "writable": true
+        },
+        {
+          "name": "protocol_position"
+        },
+        {
+          "name": "token_vault_0",
+          "docs": [
+            "Token_0 vault"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_vault_1",
+          "docs": [
+            "Token_1 vault"
+          ],
+          "writable": true
+        },
+        {
+          "name": "tick_array_lower",
+          "docs": [
+            "Stores init state for the lower tick"
+          ],
+          "writable": true
+        },
+        {
+          "name": "tick_array_upper",
+          "docs": [
+            "Stores init state for the upper tick"
+          ],
+          "writable": true
+        },
+        {
+          "name": "recipient_token_account_0",
+          "docs": [
+            "The destination token account for receive amount_0"
+          ],
+          "writable": true
+        },
+        {
+          "name": "recipient_token_account_1",
+          "docs": [
+            "The destination token account for receive amount_1"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL program to transfer out tokens"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_program_2022",
+          "docs": [
+            "Token program 2022"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "memo_program",
+          "docs": [
+            "memo program"
+          ],
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "vault_0_mint",
+          "docs": [
+            "The mint of token vault 0"
+          ]
+        },
+        {
+          "name": "vault_1_mint",
+          "docs": [
+            "The mint of token vault 1"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity",
+          "type": "u128"
+        },
+        {
+          "name": "amount_0_min",
+          "type": "u64"
+        },
+        {
+          "name": "amount_1_min",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "increase_limit_order",
+      "docs": [
+        "Increase a limit order",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `amount` - The increase amount of the order",
+        "* `is_increase` - The direction of the order, true: increase, false: decrease",
+        ""
+      ],
+      "discriminator": [
+        177,
+        144,
+        89,
+        236,
+        250,
+        186,
+        125,
+        99
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "signer": true
+        },
+        {
+          "name": "pool_state"
+        },
+        {
+          "name": "tick_array",
+          "writable": true
+        },
+        {
+          "name": "limit_order",
+          "writable": true
+        },
+        {
+          "name": "input_token_account",
+          "docs": [
+            "The payer's limit order token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "input_vault",
+          "docs": [
+            "The address that holds limit order token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "input_vault_mint",
+          "docs": [
+            "The mint of token vault"
+          ]
+        },
+        {
+          "name": "input_token_program",
+          "docs": [
+            "SPL-TOKEN / SPL-TOKEN2022 program for token transfers"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "increase_liquidity",
       "docs": [
         "#[deprecated(note = \"Use `increase_liquidity_v2` instead.\")]",
-        "Increases liquidity with a exist position, with amount paid by `payer`",
+        "Increases liquidity for an existing position, with amount paid by `payer`",
         "",
         "# Arguments",
         "",
@@ -1592,96 +1765,92 @@
         "* `amount_1_max` - The max amount of token_1 to spend, which serves as a slippage check",
         ""
       ],
+      "discriminator": [
+        46,
+        156,
+        243,
+        118,
+        13,
+        205,
+        251,
+        178
+      ],
       "accounts": [
         {
-          "name": "nftOwner",
-          "isMut": false,
-          "isSigner": true,
+          "name": "nft_owner",
           "docs": [
             "Pays to mint the position"
-          ]
+          ],
+          "signer": true
         },
         {
-          "name": "nftAccount",
-          "isMut": false,
-          "isSigner": false,
+          "name": "nft_account",
           "docs": [
             "The token account for nft"
           ]
         },
         {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false
+          "name": "pool_state",
+          "writable": true
         },
         {
-          "name": "protocolPosition",
-          "isMut": true,
-          "isSigner": false
+          "name": "protocol_position"
         },
         {
-          "name": "personalPosition",
-          "isMut": true,
-          "isSigner": false,
+          "name": "personal_position",
           "docs": [
             "Increase liquidity for this position"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "tickArrayLower",
-          "isMut": true,
-          "isSigner": false,
+          "name": "tick_array_lower",
           "docs": [
             "Stores init state for the lower tick"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "tickArrayUpper",
-          "isMut": true,
-          "isSigner": false,
+          "name": "tick_array_upper",
           "docs": [
             "Stores init state for the upper tick"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "tokenAccount0",
-          "isMut": true,
-          "isSigner": false,
+          "name": "token_account_0",
           "docs": [
             "The payer's token account for token_0"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "tokenAccount1",
-          "isMut": true,
-          "isSigner": false,
+          "name": "token_account_1",
           "docs": [
             "The token account spending token_1 to mint the position"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "tokenVault0",
-          "isMut": true,
-          "isSigner": false,
+          "name": "token_vault_0",
           "docs": [
             "The address that holds pool tokens for token_0"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "tokenVault1",
-          "isMut": true,
-          "isSigner": false,
+          "name": "token_vault_1",
           "docs": [
             "The address that holds pool tokens for token_1"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_program",
           "docs": [
             "Program to create mint account and mint tokens"
-          ]
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         }
       ],
       "args": [
@@ -1690,19 +1859,19 @@
           "type": "u128"
         },
         {
-          "name": "amount0Max",
+          "name": "amount_0_max",
           "type": "u64"
         },
         {
-          "name": "amount1Max",
+          "name": "amount_1_max",
           "type": "u64"
         }
       ]
     },
     {
-      "name": "increaseLiquidityV2",
+      "name": "increase_liquidity_v2",
       "docs": [
-        "Increases liquidity with a exist position, with amount paid by `payer`, support Token2022",
+        "Increases liquidity for an existing position, with amount paid by `payer`, support Token2022",
         "",
         "# Arguments",
         "",
@@ -1713,117 +1882,108 @@
         "* `base_flag` - must be specified if liquidity is zero, true: calculate liquidity base amount_0_max otherwise base amount_1_max",
         ""
       ],
+      "discriminator": [
+        133,
+        29,
+        89,
+        223,
+        69,
+        238,
+        176,
+        10
+      ],
       "accounts": [
         {
-          "name": "nftOwner",
-          "isMut": false,
-          "isSigner": true,
+          "name": "nft_owner",
           "docs": [
             "Pays to mint the position"
-          ]
+          ],
+          "signer": true
         },
         {
-          "name": "nftAccount",
-          "isMut": false,
-          "isSigner": false,
+          "name": "nft_account",
           "docs": [
             "The token account for nft"
           ]
         },
         {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false
+          "name": "pool_state",
+          "writable": true
         },
         {
-          "name": "protocolPosition",
-          "isMut": true,
-          "isSigner": false
+          "name": "protocol_position"
         },
         {
-          "name": "personalPosition",
-          "isMut": true,
-          "isSigner": false,
+          "name": "personal_position",
           "docs": [
             "Increase liquidity for this position"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "tickArrayLower",
-          "isMut": true,
-          "isSigner": false,
+          "name": "tick_array_lower",
           "docs": [
             "Stores init state for the lower tick"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "tickArrayUpper",
-          "isMut": true,
-          "isSigner": false,
+          "name": "tick_array_upper",
           "docs": [
             "Stores init state for the upper tick"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "tokenAccount0",
-          "isMut": true,
-          "isSigner": false,
+          "name": "token_account_0",
           "docs": [
             "The payer's token account for token_0"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "tokenAccount1",
-          "isMut": true,
-          "isSigner": false,
+          "name": "token_account_1",
           "docs": [
             "The token account spending token_1 to mint the position"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "tokenVault0",
-          "isMut": true,
-          "isSigner": false,
+          "name": "token_vault_0",
           "docs": [
             "The address that holds pool tokens for token_0"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "tokenVault1",
-          "isMut": true,
-          "isSigner": false,
+          "name": "token_vault_1",
           "docs": [
             "The address that holds pool tokens for token_1"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_program",
           "docs": [
             "Program to create mint account and mint tokens"
-          ]
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
         {
-          "name": "tokenProgram2022",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_program_2022",
           "docs": [
             "Token program 2022"
-          ]
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
         },
         {
-          "name": "vault0Mint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_0_mint",
           "docs": [
             "The mint of token vault 0"
           ]
         },
         {
-          "name": "vault1Mint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_1_mint",
           "docs": [
             "The mint of token vault 1"
           ]
@@ -1835,15 +1995,15 @@
           "type": "u128"
         },
         {
-          "name": "amount0Max",
+          "name": "amount_0_max",
           "type": "u64"
         },
         {
-          "name": "amount1Max",
+          "name": "amount_1_max",
           "type": "u64"
         },
         {
-          "name": "baseFlag",
+          "name": "base_flag",
           "type": {
             "option": "bool"
           }
@@ -1851,258 +2011,943 @@
       ]
     },
     {
-      "name": "decreaseLiquidity",
+      "name": "initialize_reward",
       "docs": [
-        "#[deprecated(note = \"Use `decrease_liquidity_v2` instead.\")]",
-        "Decreases liquidity with a exist position",
+        "Initialize a reward info for a given pool and reward index",
         "",
         "# Arguments",
         "",
-        "* `ctx` -  The context of accounts",
-        "* `liquidity` - The amount by which liquidity will be decreased",
-        "* `amount_0_min` - The minimum amount of token_0 that should be accounted for the burned liquidity",
-        "* `amount_1_min` - The minimum amount of token_1 that should be accounted for the burned liquidity",
+        "* `ctx` - The context of accounts",
+        "* `reward_index` - the index to reward info",
+        "* `open_time` - reward open timestamp",
+        "* `end_time` - reward end timestamp",
+        "* `emissions_per_second_x64` - Token reward per second are earned per unit of liquidity.",
         ""
+      ],
+      "discriminator": [
+        95,
+        135,
+        192,
+        196,
+        242,
+        129,
+        230,
+        68
       ],
       "accounts": [
         {
-          "name": "nftOwner",
-          "isMut": false,
-          "isSigner": true,
+          "name": "reward_funder",
           "docs": [
-            "The position owner or delegated authority"
+            "The founder deposit reward token to vault"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "funder_token_account",
+          "writable": true
+        },
+        {
+          "name": "amm_config",
+          "docs": [
+            "For check the reward_funder authority"
           ]
         },
         {
-          "name": "nftAccount",
-          "isMut": false,
-          "isSigner": false,
+          "name": "pool_state",
           "docs": [
-            "The token account for the tokenized position"
+            "Set reward for this pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "operation_state",
+          "docs": [
+            "load info from the account to judge reward permission"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  112,
+                  101,
+                  114,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "reward_token_mint",
+          "docs": [
+            "Reward mint"
           ]
         },
         {
-          "name": "personalPosition",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Decrease liquidity for this position"
-          ]
+          "name": "reward_token_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  114,
+                  101,
+                  119,
+                  97,
+                  114,
+                  100,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "account",
+                "path": "reward_token_mint"
+              }
+            ]
+          }
         },
         {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false
+          "name": "reward_token_program"
         },
         {
-          "name": "protocolPosition",
-          "isMut": true,
-          "isSigner": false
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         },
         {
-          "name": "tokenVault0",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Token_0 vault"
-          ]
-        },
-        {
-          "name": "tokenVault1",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Token_1 vault"
-          ]
-        },
-        {
-          "name": "tickArrayLower",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Stores init state for the lower tick"
-          ]
-        },
-        {
-          "name": "tickArrayUpper",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Stores init state for the upper tick"
-          ]
-        },
-        {
-          "name": "recipientTokenAccount0",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "The destination token account for receive amount_0"
-          ]
-        },
-        {
-          "name": "recipientTokenAccount1",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "The destination token account for receive amount_1"
-          ]
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "SPL program to transfer out tokens"
-          ]
+          "name": "rent",
+          "address": "SysvarRent111111111111111111111111111111111"
         }
       ],
       "args": [
         {
-          "name": "liquidity",
-          "type": "u128"
+          "name": "param",
+          "type": {
+            "defined": {
+              "name": "InitializeRewardParam"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "open_limit_order",
+      "docs": [
+        "Place a limit order",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `nonce_index` - The limit order nonce account index, used to create user's order nonce PDA account.",
+        "* `zero_for_one` - The direction of the order, true: zero for one, false: one for zero",
+        "* `tick_index` - The index of the tick",
+        "* `amount` - The amount of the order",
+        "* `with_metadata` - The flag indicating whether to create NFT mint metadata",
+        ""
+      ],
+      "discriminator": [
+        157,
+        32,
+        218,
+        183,
+        71,
+        29,
+        18,
+        147
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "amount0Min",
-          "type": "u64"
+          "name": "pool_state",
+          "docs": [
+            "The pool"
+          ],
+          "writable": true
         },
         {
-          "name": "amount1Min",
+          "name": "tick_array",
+          "writable": true
+        },
+        {
+          "name": "limit_order_nonce",
+          "docs": [
+            "The order nonce account PDA"
+          ],
+          "writable": true
+        },
+        {
+          "name": "limit_order",
+          "docs": [
+            "The order account PDA"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "payer"
+              },
+              {
+                "kind": "account",
+                "path": "limit_order_nonce"
+              },
+              {
+                "kind": "account",
+                "path": "limit_order_nonce.order_nonce",
+                "account": "LimitOrderNonce"
+              }
+            ]
+          }
+        },
+        {
+          "name": "input_token_account",
+          "docs": [
+            "The payer's limit order token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "input_vault",
+          "docs": [
+            "The address that holds limit order token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "input_vault_mint",
+          "docs": [
+            "The mint of token vault"
+          ]
+        },
+        {
+          "name": "input_token_program",
+          "docs": [
+            "SPL-TOKEN / SPL-TOKEN2022 program for input token transfers"
+          ]
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "SPL program for system operations"
+          ],
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "nonce_index",
+          "type": "u8"
+        },
+        {
+          "name": "zero_for_one",
+          "type": "bool"
+        },
+        {
+          "name": "tick_index",
+          "type": "i32"
+        },
+        {
+          "name": "amount",
           "type": "u64"
         }
       ]
     },
     {
-      "name": "decreaseLiquidityV2",
+      "name": "open_position",
       "docs": [
-        "Decreases liquidity with a exist position, support Token2022",
+        "#[deprecated(note = \"Use `open_position_with_token22_nft` instead.\")]",
+        "Creates a new position wrapped in a NFT",
         "",
         "# Arguments",
         "",
-        "* `ctx` -  The context of accounts",
-        "* `liquidity` - The amount by which liquidity will be decreased",
-        "* `amount_0_min` - The minimum amount of token_0 that should be accounted for the burned liquidity",
-        "* `amount_1_min` - The minimum amount of token_1 that should be accounted for the burned liquidity",
+        "* `ctx` - The context of accounts",
+        "* `tick_lower_index` - The low boundary of market",
+        "* `tick_upper_index` - The upper boundary of market",
+        "* `tick_array_lower_start_index` - The start index of tick array which includes tick low",
+        "* `tick_array_upper_start_index` - The start index of tick array which includes tick upper",
+        "* `liquidity` - The liquidity to be added",
+        "* `amount_0_max` - The max amount of token_0 to spend, which serves as a slippage check",
+        "* `amount_1_max` - The max amount of token_1 to spend, which serves as a slippage check",
         ""
+      ],
+      "discriminator": [
+        135,
+        128,
+        47,
+        77,
+        15,
+        152,
+        240,
+        49
       ],
       "accounts": [
         {
-          "name": "nftOwner",
-          "isMut": false,
-          "isSigner": true,
+          "name": "payer",
           "docs": [
-            "The position owner or delegated authority"
-          ]
+            "Pays to mint the position"
+          ],
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "nftAccount",
-          "isMut": false,
-          "isSigner": false,
+          "name": "position_nft_owner"
+        },
+        {
+          "name": "position_nft_mint",
           "docs": [
-            "The token account for the tokenized position"
-          ]
+            "Unique token mint address"
+          ],
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "personalPosition",
-          "isMut": true,
-          "isSigner": false,
+          "name": "position_nft_account",
           "docs": [
-            "Decrease liquidity for this position"
-          ]
+            "Token account where position NFT will be minted",
+            "This account created in the contract by cpi to avoid large stack variables"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "position_nft_owner"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "position_nft_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
         },
         {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "protocolPosition",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVault0",
-          "isMut": true,
-          "isSigner": false,
+          "name": "metadata_account",
           "docs": [
-            "Token_0 vault"
-          ]
+            "To store metaplex metadata"
+          ],
+          "writable": true
         },
         {
-          "name": "tokenVault1",
-          "isMut": true,
-          "isSigner": false,
+          "name": "pool_state",
           "docs": [
-            "Token_1 vault"
-          ]
+            "Add liquidity for this pool"
+          ],
+          "writable": true
         },
         {
-          "name": "tickArrayLower",
-          "isMut": true,
-          "isSigner": false,
+          "name": "protocol_position"
+        },
+        {
+          "name": "tick_array_lower",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  105,
+                  99,
+                  107,
+                  95,
+                  97,
+                  114,
+                  114,
+                  97,
+                  121
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "arg",
+                "path": "tick_array_lower_start_index"
+              }
+            ]
+          }
+        },
+        {
+          "name": "tick_array_upper",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  105,
+                  99,
+                  107,
+                  95,
+                  97,
+                  114,
+                  114,
+                  97,
+                  121
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "arg",
+                "path": "tick_array_upper_start_index"
+              }
+            ]
+          }
+        },
+        {
+          "name": "personal_position",
           "docs": [
-            "Stores init state for the lower tick"
-          ]
+            "personal position state"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "position_nft_mint"
+              }
+            ]
+          }
         },
         {
-          "name": "tickArrayUpper",
-          "isMut": true,
-          "isSigner": false,
+          "name": "token_account_0",
           "docs": [
-            "Stores init state for the upper tick"
-          ]
+            "The token_0 account deposit token to the pool"
+          ],
+          "writable": true
         },
         {
-          "name": "recipientTokenAccount0",
-          "isMut": true,
-          "isSigner": false,
+          "name": "token_account_1",
           "docs": [
-            "The destination token account for receive amount_0"
-          ]
+            "The token_1 account deposit token to the pool"
+          ],
+          "writable": true
         },
         {
-          "name": "recipientTokenAccount1",
-          "isMut": true,
-          "isSigner": false,
+          "name": "token_vault_0",
           "docs": [
-            "The destination token account for receive amount_1"
-          ]
+            "The address that holds pool tokens for token_0"
+          ],
+          "writable": true
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_vault_1",
           "docs": [
-            "SPL program to transfer out tokens"
-          ]
+            "The address that holds pool tokens for token_1"
+          ],
+          "writable": true
         },
         {
-          "name": "tokenProgram2022",
-          "isMut": false,
-          "isSigner": false,
+          "name": "rent",
           "docs": [
-            "Token program 2022"
-          ]
+            "Sysvar for token mint and ATA creation"
+          ],
+          "address": "SysvarRent111111111111111111111111111111111"
         },
         {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "system_program",
           "docs": [
-            "memo program"
-          ]
+            "Program to create the position manager state account"
+          ],
+          "address": "11111111111111111111111111111111"
         },
         {
-          "name": "vault0Mint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_program",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Program to create an ATA for receiving position NFT"
+          ],
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "metadata_program",
+          "docs": [
+            "Program to create NFT metadata"
+          ],
+          "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+        }
+      ],
+      "args": [
+        {
+          "name": "tick_lower_index",
+          "type": "i32"
+        },
+        {
+          "name": "tick_upper_index",
+          "type": "i32"
+        },
+        {
+          "name": "tick_array_lower_start_index",
+          "type": "i32"
+        },
+        {
+          "name": "tick_array_upper_start_index",
+          "type": "i32"
+        },
+        {
+          "name": "liquidity",
+          "type": "u128"
+        },
+        {
+          "name": "amount_0_max",
+          "type": "u64"
+        },
+        {
+          "name": "amount_1_max",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "open_position_v2",
+      "docs": [
+        "#[deprecated(note = \"Use `open_position_with_token22_nft` instead.\")]",
+        "Creates a new position wrapped in a NFT, support Token2022",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `tick_lower_index` - The low boundary of market",
+        "* `tick_upper_index` - The upper boundary of market",
+        "* `tick_array_lower_start_index` - The start index of tick array which includes tick low",
+        "* `tick_array_upper_start_index` - The start index of tick array which includes tick upper",
+        "* `liquidity` - The liquidity to be added, if zero, and the base_flag is specified, calculate liquidity base amount_0_max or amount_1_max according base_flag, otherwise open position with zero liquidity",
+        "* `amount_0_max` - The max amount of token_0 to spend, which serves as a slippage check",
+        "* `amount_1_max` - The max amount of token_1 to spend, which serves as a slippage check",
+        "* `with_metadata` - The flag indicating whether to create NFT mint metadata",
+        "* `base_flag` - if the liquidity specified as zero, true: calculate liquidity base amount_0_max otherwise base amount_1_max",
+        ""
+      ],
+      "discriminator": [
+        77,
+        184,
+        74,
+        214,
+        112,
+        86,
+        241,
+        199
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "docs": [
+            "Pays to mint the position"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "position_nft_owner"
+        },
+        {
+          "name": "position_nft_mint",
+          "docs": [
+            "Unique token mint address"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "Token account where position NFT will be minted"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "position_nft_owner"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "position_nft_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "metadata_account",
+          "docs": [
+            "To store metaplex metadata"
+          ],
+          "writable": true
+        },
+        {
+          "name": "pool_state",
+          "docs": [
+            "Add liquidity for this pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "protocol_position"
+        },
+        {
+          "name": "tick_array_lower",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  105,
+                  99,
+                  107,
+                  95,
+                  97,
+                  114,
+                  114,
+                  97,
+                  121
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "arg",
+                "path": "tick_array_lower_start_index"
+              }
+            ]
+          }
+        },
+        {
+          "name": "tick_array_upper",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  105,
+                  99,
+                  107,
+                  95,
+                  97,
+                  114,
+                  114,
+                  97,
+                  121
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "arg",
+                "path": "tick_array_upper_start_index"
+              }
+            ]
+          }
+        },
+        {
+          "name": "personal_position",
+          "docs": [
+            "personal position state"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "position_nft_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_account_0",
+          "docs": [
+            "The token_0 account deposit token to the pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_account_1",
+          "docs": [
+            "The token_1 account deposit token to the pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_vault_0",
+          "docs": [
+            "The address that holds pool tokens for token_0"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_vault_1",
+          "docs": [
+            "The address that holds pool tokens for token_1"
+          ],
+          "writable": true
+        },
+        {
+          "name": "rent",
+          "docs": [
+            "Sysvar for token mint and ATA creation"
+          ],
+          "address": "SysvarRent111111111111111111111111111111111"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "Program to create the position manager state account"
+          ],
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Program to create an ATA for receiving position NFT"
+          ],
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "metadata_program",
+          "docs": [
+            "Program to create NFT metadata"
+          ],
+          "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+        },
+        {
+          "name": "token_program_2022",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "vault_0_mint",
           "docs": [
             "The mint of token vault 0"
           ]
         },
         {
-          "name": "vault1Mint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_1_mint",
           "docs": [
             "The mint of token vault 1"
           ]
@@ -2110,18 +2955,476 @@
       ],
       "args": [
         {
+          "name": "tick_lower_index",
+          "type": "i32"
+        },
+        {
+          "name": "tick_upper_index",
+          "type": "i32"
+        },
+        {
+          "name": "tick_array_lower_start_index",
+          "type": "i32"
+        },
+        {
+          "name": "tick_array_upper_start_index",
+          "type": "i32"
+        },
+        {
           "name": "liquidity",
           "type": "u128"
         },
         {
-          "name": "amount0Min",
+          "name": "amount_0_max",
           "type": "u64"
         },
         {
-          "name": "amount1Min",
+          "name": "amount_1_max",
+          "type": "u64"
+        },
+        {
+          "name": "with_metadata",
+          "type": "bool"
+        },
+        {
+          "name": "base_flag",
+          "type": {
+            "option": "bool"
+          }
+        }
+      ]
+    },
+    {
+      "name": "open_position_with_token22_nft",
+      "docs": [
+        "Creates a new position wrapped in a Token2022 NFT without relying on metadata_program and metadata_account, reduce the cost for user to create a personal position.",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `tick_lower_index` - The low boundary of market",
+        "* `tick_upper_index` - The upper boundary of market",
+        "* `tick_array_lower_start_index` - The start index of tick array which includes tick low",
+        "* `tick_array_upper_start_index` - The start index of tick array which includes tick upper",
+        "* `liquidity` - The liquidity to be added, if zero, and the base_flag is specified, calculate liquidity base amount_0_max or amount_1_max according base_flag, otherwise open position with zero liquidity",
+        "* `amount_0_max` - The max amount of token_0 to spend, which serves as a slippage check",
+        "* `amount_1_max` - The max amount of token_1 to spend, which serves as a slippage check",
+        "* `with_metadata` - The flag indicating whether to create NFT mint metadata",
+        "* `base_flag` - if the liquidity specified as zero, true: calculate liquidity base amount_0_max otherwise base amount_1_max",
+        ""
+      ],
+      "discriminator": [
+        77,
+        255,
+        174,
+        82,
+        125,
+        29,
+        201,
+        46
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "docs": [
+            "Pays to mint the position"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "position_nft_owner"
+        },
+        {
+          "name": "position_nft_mint",
+          "docs": [
+            "Unique token mint address, initialize in contract"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "position_nft_account",
+          "writable": true
+        },
+        {
+          "name": "pool_state",
+          "docs": [
+            "Add liquidity for this pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "protocol_position"
+        },
+        {
+          "name": "tick_array_lower",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  105,
+                  99,
+                  107,
+                  95,
+                  97,
+                  114,
+                  114,
+                  97,
+                  121
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "arg",
+                "path": "tick_array_lower_start_index"
+              }
+            ]
+          }
+        },
+        {
+          "name": "tick_array_upper",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  105,
+                  99,
+                  107,
+                  95,
+                  97,
+                  114,
+                  114,
+                  97,
+                  121
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "arg",
+                "path": "tick_array_upper_start_index"
+              }
+            ]
+          }
+        },
+        {
+          "name": "personal_position",
+          "docs": [
+            "personal position state"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "position_nft_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_account_0",
+          "docs": [
+            "The token_0 account deposit token to the pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_account_1",
+          "docs": [
+            "The token_1 account deposit token to the pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_vault_0",
+          "docs": [
+            "The address that holds pool tokens for token_0"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_vault_1",
+          "docs": [
+            "The address that holds pool tokens for token_1"
+          ],
+          "writable": true
+        },
+        {
+          "name": "rent",
+          "docs": [
+            "Sysvar for token mint and ATA creation"
+          ],
+          "address": "SysvarRent111111111111111111111111111111111"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "Program to create the position manager state account"
+          ],
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Program to transfer for token account"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Program to create an ATA for receiving position NFT"
+          ],
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "token_program_2022",
+          "docs": [
+            "Program to create NFT mint/token account and transfer for token22 account"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "vault_0_mint",
+          "docs": [
+            "The mint of token vault 0"
+          ]
+        },
+        {
+          "name": "vault_1_mint",
+          "docs": [
+            "The mint of token vault 1"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "tick_lower_index",
+          "type": "i32"
+        },
+        {
+          "name": "tick_upper_index",
+          "type": "i32"
+        },
+        {
+          "name": "tick_array_lower_start_index",
+          "type": "i32"
+        },
+        {
+          "name": "tick_array_upper_start_index",
+          "type": "i32"
+        },
+        {
+          "name": "liquidity",
+          "type": "u128"
+        },
+        {
+          "name": "amount_0_max",
+          "type": "u64"
+        },
+        {
+          "name": "amount_1_max",
+          "type": "u64"
+        },
+        {
+          "name": "with_metadata",
+          "type": "bool"
+        },
+        {
+          "name": "base_flag",
+          "type": {
+            "option": "bool"
+          }
+        }
+      ]
+    },
+    {
+      "name": "set_reward_params",
+      "docs": [
+        "Reset reward param, start a new reward cycle or extend the current cycle.",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `reward_index` - The index of reward token in the pool.",
+        "* `emissions_per_second_x64` - The per second emission reward, when extend the current cycle,",
+        "new value can't be less than old value",
+        "* `open_time` - reward open timestamp, must be set when starting a new cycle",
+        "* `end_time` - reward end timestamp",
+        ""
+      ],
+      "discriminator": [
+        112,
+        52,
+        167,
+        75,
+        32,
+        201,
+        211,
+        137
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "docs": [
+            "Address to be set as protocol owner. It pays to create factory state account."
+          ],
+          "signer": true
+        },
+        {
+          "name": "amm_config"
+        },
+        {
+          "name": "pool_state",
+          "writable": true
+        },
+        {
+          "name": "operation_state",
+          "docs": [
+            "load info from the account to judge reward permission"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  112,
+                  101,
+                  114,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_program_2022",
+          "docs": [
+            "Token program 2022"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u8"
+        },
+        {
+          "name": "emissions_per_second_x64",
+          "type": "u128"
+        },
+        {
+          "name": "open_time",
+          "type": "u64"
+        },
+        {
+          "name": "end_time",
           "type": "u64"
         }
       ]
+    },
+    {
+      "name": "settle_limit_order",
+      "docs": [
+        "Settle a limit order",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        ""
+      ],
+      "discriminator": [
+        205,
+        78,
+        116,
+        33,
+        92,
+        105,
+        26,
+        96
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "pool_state"
+        },
+        {
+          "name": "tick_array"
+        },
+        {
+          "name": "limit_order",
+          "writable": true
+        },
+        {
+          "name": "output_token_account",
+          "docs": [
+            "The owner's output token account (opposite direction from input)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "output_vault",
+          "docs": [
+            "The address that holds output tokens"
+          ],
+          "writable": true
+        },
+        {
+          "name": "output_vault_mint",
+          "docs": [
+            "The mint of output vault"
+          ]
+        },
+        {
+          "name": "output_token_program",
+          "docs": [
+            "SPL-TOKEN / SPL-TOKEN2022 program for token transfers"
+          ]
+        }
+      ],
+      "args": []
     },
     {
       "name": "swap",
@@ -2138,83 +3441,82 @@
         "* `is_base_input` - swap base input or swap base output",
         ""
       ],
+      "discriminator": [
+        248,
+        198,
+        158,
+        145,
+        225,
+        117,
+        135,
+        200
+      ],
       "accounts": [
         {
           "name": "payer",
-          "isMut": false,
-          "isSigner": true,
           "docs": [
             "The user performing the swap"
-          ]
+          ],
+          "signer": true
         },
         {
-          "name": "ammConfig",
-          "isMut": false,
-          "isSigner": false,
+          "name": "amm_config",
           "docs": [
             "The factory state to read protocol fees"
           ]
         },
         {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false,
+          "name": "pool_state",
           "docs": [
             "The program account of the pool in which the swap will be performed"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "inputTokenAccount",
-          "isMut": true,
-          "isSigner": false,
+          "name": "input_token_account",
           "docs": [
             "The user token account for input token"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "outputTokenAccount",
-          "isMut": true,
-          "isSigner": false,
+          "name": "output_token_account",
           "docs": [
             "The user token account for output token"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "inputVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "input_vault",
           "docs": [
             "The vault token account for input token"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "outputVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "output_vault",
           "docs": [
             "The vault token account for output token"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "observationState",
-          "isMut": true,
-          "isSigner": false,
+          "name": "observation_state",
           "docs": [
             "The program account for the most recent oracle observation"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_program",
           "docs": [
             "SPL program for token transfers"
-          ]
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
         {
-          "name": "tickArray",
-          "isMut": true,
-          "isSigner": false
+          "name": "tick_array",
+          "writable": true
         }
       ],
       "args": [
@@ -2223,21 +3525,98 @@
           "type": "u64"
         },
         {
-          "name": "otherAmountThreshold",
+          "name": "other_amount_threshold",
           "type": "u64"
         },
         {
-          "name": "sqrtPriceLimitX64",
+          "name": "sqrt_price_limit_x64",
           "type": "u128"
         },
         {
-          "name": "isBaseInput",
+          "name": "is_base_input",
           "type": "bool"
         }
       ]
     },
     {
-      "name": "swapV2",
+      "name": "swap_router_base_in",
+      "docs": [
+        "Swap token for as much as possible of another token across the path provided, base input",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `amount_in` - Token amount to be swapped in",
+        "* `amount_out_minimum` - Panic if output amount is below minimum amount. For slippage.",
+        ""
+      ],
+      "discriminator": [
+        69,
+        125,
+        115,
+        218,
+        245,
+        186,
+        242,
+        196
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "docs": [
+            "The user performing the swap"
+          ],
+          "signer": true
+        },
+        {
+          "name": "input_token_account",
+          "docs": [
+            "The token account that pays input tokens for the swap"
+          ],
+          "writable": true
+        },
+        {
+          "name": "input_token_mint",
+          "docs": [
+            "The mint of input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL program for token transfers"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_program_2022",
+          "docs": [
+            "SPL program 2022 for token transfers"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "memo_program",
+          "docs": [
+            "Memo program"
+          ],
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount_in",
+          "type": "u64"
+        },
+        {
+          "name": "amount_out_minimum",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "swap_v2",
       "docs": [
         "Swaps one token for as much as possible of another token across a single pool, support token program 2022",
         "",
@@ -2250,104 +3629,101 @@
         "* `is_base_input` - swap base input or swap base output",
         ""
       ],
+      "discriminator": [
+        43,
+        4,
+        237,
+        11,
+        26,
+        201,
+        30,
+        98
+      ],
       "accounts": [
         {
           "name": "payer",
-          "isMut": false,
-          "isSigner": true,
           "docs": [
             "The user performing the swap"
-          ]
+          ],
+          "signer": true
         },
         {
-          "name": "ammConfig",
-          "isMut": false,
-          "isSigner": false,
+          "name": "amm_config",
           "docs": [
             "The factory state to read protocol fees"
           ]
         },
         {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false,
+          "name": "pool_state",
           "docs": [
             "The program account of the pool in which the swap will be performed"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "inputTokenAccount",
-          "isMut": true,
-          "isSigner": false,
+          "name": "input_token_account",
           "docs": [
             "The user token account for input token"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "outputTokenAccount",
-          "isMut": true,
-          "isSigner": false,
+          "name": "output_token_account",
           "docs": [
             "The user token account for output token"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "inputVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "input_vault",
           "docs": [
             "The vault token account for input token"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "outputVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "output_vault",
           "docs": [
             "The vault token account for output token"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "observationState",
-          "isMut": true,
-          "isSigner": false,
+          "name": "observation_state",
           "docs": [
             "The program account for the most recent oracle observation"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_program",
           "docs": [
             "SPL program for token transfers"
-          ]
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         },
         {
-          "name": "tokenProgram2022",
-          "isMut": false,
-          "isSigner": false,
+          "name": "token_program_2022",
           "docs": [
             "SPL program 2022 for token transfers"
-          ]
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
         },
         {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "memo_program",
+          "docs": [
+            "Memo program"
+          ],
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
         },
         {
-          "name": "inputVaultMint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "input_vault_mint",
           "docs": [
             "The mint of token vault 0"
           ]
         },
         {
-          "name": "outputVaultMint",
-          "isMut": false,
-          "isSigner": false,
+          "name": "output_vault_mint",
           "docs": [
             "The mint of token vault 1"
           ]
@@ -2359,91 +3735,948 @@
           "type": "u64"
         },
         {
-          "name": "otherAmountThreshold",
+          "name": "other_amount_threshold",
           "type": "u64"
         },
         {
-          "name": "sqrtPriceLimitX64",
+          "name": "sqrt_price_limit_x64",
           "type": "u128"
         },
         {
-          "name": "isBaseInput",
+          "name": "is_base_input",
           "type": "bool"
         }
       ]
     },
     {
-      "name": "swapRouterBaseIn",
+      "name": "transfer_reward_owner",
       "docs": [
-        "Swap token for as much as possible of another token across the path provided, base input",
+        "Transfer reward owner",
         "",
         "# Arguments",
         "",
         "* `ctx` - The context of accounts",
-        "* `amount_in` - Token amount to be swapped in",
-        "* `amount_out_minimum` - Panic if output amount is below minimum amount. For slippage.",
+        "* `new_owner` - new owner pubkey",
         ""
+      ],
+      "discriminator": [
+        7,
+        22,
+        12,
+        83,
+        242,
+        43,
+        48,
+        121
       ],
       "accounts": [
         {
-          "name": "payer",
-          "isMut": false,
-          "isSigner": true,
+          "name": "authority",
           "docs": [
-            "The user performing the swap"
-          ]
+            "Address to be set as operation account owner."
+          ],
+          "signer": true,
+          "address": "2kqJncUWCkk5TyJYamPW5DECfqAz4brYpH6r5j6vg9yx"
         },
         {
-          "name": "inputTokenAccount",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "The token account that pays input tokens for the swap"
-          ]
-        },
-        {
-          "name": "inputTokenMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "The mint of input token"
-          ]
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "SPL program for token transfers"
-          ]
-        },
-        {
-          "name": "tokenProgram2022",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "SPL program 2022 for token transfers"
-          ]
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
+          "name": "pool_state",
+          "writable": true
         }
       ],
       "args": [
         {
-          "name": "amountIn",
-          "type": "u64"
-        },
-        {
-          "name": "amountOutMinimum",
-          "type": "u64"
+          "name": "new_owner",
+          "type": "pubkey"
         }
       ]
+    },
+    {
+      "name": "update_amm_config",
+      "docs": [
+        "Updates the owner of the amm config",
+        "Must be called by the current owner or admin",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `trade_fee_rate` - The new trade fee rate of amm config, be set when `param` is 0",
+        "* `protocol_fee_rate` - The new protocol fee rate of amm config, be set when `param` is 1",
+        "* `fund_fee_rate` - The new fund fee rate of amm config, be set when `param` is 2",
+        "* `new_owner` - The config's new owner, be set when `param` is 3",
+        "* `new_fund_owner` - The config's new fund owner, be set when `param` is 4",
+        "* `limit_protocol_fee_rate` - The new limit protocol fee rate of amm config, be set when `param` is 5",
+        "* `limit_fund_fee_rate` - The new limit fund fee rate of amm config, be set when `param` is 6",
+        "* `param` - The value can be 0 | 1 | 2 | 3 | 4 | 5 | 6, otherwise will report an error",
+        ""
+      ],
+      "discriminator": [
+        49,
+        60,
+        174,
+        136,
+        154,
+        28,
+        116,
+        200
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "docs": [
+            "The amm config owner or admin"
+          ],
+          "signer": true,
+          "address": "2kqJncUWCkk5TyJYamPW5DECfqAz4brYpH6r5j6vg9yx"
+        },
+        {
+          "name": "amm_config",
+          "docs": [
+            "Amm config account to be changed"
+          ],
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "param",
+          "type": "u8"
+        },
+        {
+          "name": "value",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "update_dynamic_fee_config",
+      "docs": [
+        "Updates the dynamic fee configuration constants.",
+        "",
+        "This function allows updating the parameters that control dynamic fee calculation,",
+        "such as filter period, decay period, reduction factor, fee control factor, etc.",
+        "Only the admin or the amm config owner can update these settings.",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `filter_period` - Period that determines the high frequency trading time window (in seconds)",
+        "* `decay_period` - Period that determines when the dynamic fee starts to decrease (in seconds)",
+        "* `reduction_factor` - Dynamic fee rate decrement rate, used for volatility reference decay",
+        "* `dynamic_fee_control` - Factor used to scale the dynamic fee component",
+        "* `max_volatility_accumulator` - Maximum value for the volatility accumulator",
+        "* `create_pool_authority` - The new authority pubkey that can use this dynamic fee config to create pools"
+      ],
+      "discriminator": [
+        7,
+        7,
+        80,
+        8,
+        2,
+        199,
+        132,
+        240
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "docs": [
+            "The admin has permission to update the config"
+          ],
+          "signer": true,
+          "address": "2kqJncUWCkk5TyJYamPW5DECfqAz4brYpH6r5j6vg9yx"
+        },
+        {
+          "name": "dynamic_fee_config",
+          "docs": [
+            "The dynamic fee config account to be updated"
+          ],
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "filter_period",
+          "type": "u16"
+        },
+        {
+          "name": "decay_period",
+          "type": "u16"
+        },
+        {
+          "name": "reduction_factor",
+          "type": "u16"
+        },
+        {
+          "name": "dynamic_fee_control",
+          "type": "u32"
+        },
+        {
+          "name": "max_volatility_accumulator",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "update_operation_account",
+      "docs": [
+        "Update the operation account",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `param` - The value can be 0 | 1 | 2 | 3, otherwise will report an error",
+        "* `keys`- update operation owner when the `param` is 0",
+        "remove operation owner when the `param` is 1",
+        "update whitelist mint when the `param` is 2",
+        "remove whitelist mint when the `param` is 3",
+        ""
+      ],
+      "discriminator": [
+        127,
+        70,
+        119,
+        40,
+        188,
+        227,
+        61,
+        7
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "docs": [
+            "Address to be set as operation account owner."
+          ],
+          "signer": true,
+          "address": "2kqJncUWCkk5TyJYamPW5DECfqAz4brYpH6r5j6vg9yx"
+        },
+        {
+          "name": "operation_state",
+          "docs": [
+            "Initialize operation state account to store operation owner address and white list mint."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  112,
+                  101,
+                  114,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "param",
+          "type": "u8"
+        },
+        {
+          "name": "keys",
+          "type": {
+            "vec": "pubkey"
+          }
+        }
+      ]
+    },
+    {
+      "name": "update_pool_status",
+      "docs": [
+        "Update pool status for given value",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `status` - The value of status",
+        ""
+      ],
+      "discriminator": [
+        130,
+        87,
+        108,
+        6,
+        46,
+        224,
+        117,
+        123
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "signer": true,
+          "address": "2kqJncUWCkk5TyJYamPW5DECfqAz4brYpH6r5j6vg9yx"
+        },
+        {
+          "name": "pool_state",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "status",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "update_reward_infos",
+      "docs": [
+        "Update rewards info of the given pool, can be called for everyone",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        ""
+      ],
+      "discriminator": [
+        163,
+        172,
+        224,
+        52,
+        11,
+        154,
+        106,
+        223
+      ],
+      "accounts": [
+        {
+          "name": "pool_state",
+          "docs": [
+            "The liquidity pool for which reward info to update"
+          ],
+          "writable": true
+        }
+      ],
+      "args": []
     }
   ],
   "accounts": [
+    {
+      "name": "AmmConfig",
+      "discriminator": [
+        218,
+        244,
+        33,
+        104,
+        203,
+        203,
+        43,
+        111
+      ]
+    },
+    {
+      "name": "DynamicFeeConfig",
+      "discriminator": [
+        244,
+        226,
+        88,
+        82,
+        14,
+        59,
+        246,
+        220
+      ]
+    },
+    {
+      "name": "LimitOrderNonce",
+      "discriminator": [
+        17,
+        153,
+        236,
+        57,
+        25,
+        199,
+        231,
+        248
+      ]
+    },
+    {
+      "name": "LimitOrderState",
+      "discriminator": [
+        1,
+        238,
+        5,
+        142,
+        207,
+        62,
+        44,
+        228
+      ]
+    },
+    {
+      "name": "ObservationState",
+      "discriminator": [
+        122,
+        174,
+        197,
+        53,
+        129,
+        9,
+        165,
+        132
+      ]
+    },
+    {
+      "name": "OperationState",
+      "discriminator": [
+        19,
+        236,
+        58,
+        237,
+        81,
+        222,
+        183,
+        252
+      ]
+    },
+    {
+      "name": "PersonalPositionState",
+      "discriminator": [
+        70,
+        111,
+        150,
+        126,
+        230,
+        15,
+        25,
+        117
+      ]
+    },
+    {
+      "name": "PoolState",
+      "discriminator": [
+        247,
+        237,
+        227,
+        245,
+        215,
+        195,
+        222,
+        70
+      ]
+    },
+    {
+      "name": "ProtocolPositionState",
+      "discriminator": [
+        100,
+        226,
+        145,
+        99,
+        146,
+        218,
+        160,
+        106
+      ]
+    },
+    {
+      "name": "SupportMintAssociated",
+      "discriminator": [
+        134,
+        40,
+        183,
+        79,
+        12,
+        112,
+        162,
+        53
+      ]
+    },
+    {
+      "name": "TickArrayBitmapExtension",
+      "discriminator": [
+        60,
+        150,
+        36,
+        219,
+        97,
+        128,
+        139,
+        153
+      ]
+    },
+    {
+      "name": "TickArrayState",
+      "discriminator": [
+        192,
+        155,
+        85,
+        205,
+        49,
+        249,
+        129,
+        42
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "CollectPersonalFeeEvent",
+      "discriminator": [
+        166,
+        174,
+        105,
+        192,
+        81,
+        161,
+        83,
+        105
+      ]
+    },
+    {
+      "name": "CollectProtocolFeeEvent",
+      "discriminator": [
+        206,
+        87,
+        17,
+        79,
+        45,
+        41,
+        213,
+        61
+      ]
+    },
+    {
+      "name": "ConfigChangeEvent",
+      "discriminator": [
+        247,
+        189,
+        7,
+        119,
+        106,
+        112,
+        95,
+        151
+      ]
+    },
+    {
+      "name": "CreatePersonalPositionEvent",
+      "discriminator": [
+        100,
+        30,
+        87,
+        249,
+        196,
+        223,
+        154,
+        206
+      ]
+    },
+    {
+      "name": "DecreaseLimitOrderEvent",
+      "discriminator": [
+        70,
+        48,
+        40,
+        221,
+        219,
+        237,
+        212,
+        163
+      ]
+    },
+    {
+      "name": "DecreaseLiquidityEvent",
+      "discriminator": [
+        58,
+        222,
+        86,
+        58,
+        68,
+        50,
+        85,
+        56
+      ]
+    },
+    {
+      "name": "IncreaseLimitOrderEvent",
+      "discriminator": [
+        11,
+        120,
+        13,
+        204,
+        199,
+        87,
+        19,
+        200
+      ]
+    },
+    {
+      "name": "IncreaseLiquidityEvent",
+      "discriminator": [
+        49,
+        79,
+        105,
+        212,
+        32,
+        34,
+        30,
+        84
+      ]
+    },
+    {
+      "name": "LiquidityCalculateEvent",
+      "discriminator": [
+        237,
+        112,
+        148,
+        230,
+        57,
+        84,
+        180,
+        162
+      ]
+    },
+    {
+      "name": "LiquidityChangeEvent",
+      "discriminator": [
+        126,
+        240,
+        175,
+        206,
+        158,
+        88,
+        153,
+        107
+      ]
+    },
+    {
+      "name": "OpenLimitOrderEvent",
+      "discriminator": [
+        106,
+        24,
+        71,
+        85,
+        57,
+        169,
+        158,
+        216
+      ]
+    },
+    {
+      "name": "PoolCreatedEvent",
+      "discriminator": [
+        25,
+        94,
+        75,
+        47,
+        112,
+        99,
+        53,
+        63
+      ]
+    },
+    {
+      "name": "SettleLimitOrderEvent",
+      "discriminator": [
+        88,
+        119,
+        77,
+        164,
+        125,
+        124,
+        10,
+        194
+      ]
+    },
+    {
+      "name": "SwapEvent",
+      "discriminator": [
+        64,
+        198,
+        205,
+        232,
+        38,
+        8,
+        113,
+        226
+      ]
+    },
+    {
+      "name": "UpdateRewardInfosEvent",
+      "discriminator": [
+        109,
+        127,
+        186,
+        78,
+        114,
+        65,
+        37,
+        236
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "NotApproved",
+      "msg": "Not approved"
+    },
+    {
+      "code": 6001,
+      "name": "InvalidUpdateConfigFlag",
+      "msg": "invalid update amm config flag"
+    },
+    {
+      "code": 6002,
+      "name": "AccountLack",
+      "msg": "Account lack"
+    },
+    {
+      "code": 6003,
+      "name": "ClosePositionErr",
+      "msg": "Remove liquidity, collect fees owed and reward then you can close position account"
+    },
+    {
+      "code": 6004,
+      "name": "InvalidTickIndex",
+      "msg": "Tick out of range"
+    },
+    {
+      "code": 6005,
+      "name": "TickInvalidOrder",
+      "msg": "The lower tick must be below the upper tick"
+    },
+    {
+      "code": 6006,
+      "name": "TickLowerOverflow",
+      "msg": "The tick must be greater, or equal to the minimum tick(-443636)"
+    },
+    {
+      "code": 6007,
+      "name": "TickUpperOverflow",
+      "msg": "The tick must be lesser than, or equal to the maximum tick(443636)"
+    },
+    {
+      "code": 6008,
+      "name": "TickAndSpacingNotMatch",
+      "msg": "tick % tick_spacing must be zero"
+    },
+    {
+      "code": 6009,
+      "name": "InvalidTickArray",
+      "msg": "Invalid tick array account"
+    },
+    {
+      "code": 6010,
+      "name": "InvalidTickArrayBoundary",
+      "msg": "Invalid tick array boundary"
+    },
+    {
+      "code": 6011,
+      "name": "SqrtPriceLimitOverflow",
+      "msg": "Square root price limit overflow"
+    },
+    {
+      "code": 6012,
+      "name": "SqrtPriceX64",
+      "msg": "sqrt_price_x64 out of range"
+    },
+    {
+      "code": 6013,
+      "name": "LiquiditySubValueErr",
+      "msg": "Liquidity sub delta L must be smaller than before"
+    },
+    {
+      "code": 6014,
+      "name": "LiquidityAddValueErr",
+      "msg": "Liquidity add delta L must be greater, or equal to before"
+    },
+    {
+      "code": 6015,
+      "name": "ForbidBothZeroForSupplyLiquidity",
+      "msg": "Both token amount must not be zero while supply liquidity"
+    },
+    {
+      "code": 6016,
+      "name": "LiquidityInsufficient",
+      "msg": "Liquidity insufficient"
+    },
+    {
+      "code": 6017,
+      "name": "PriceSlippageCheck",
+      "msg": "Price slippage check"
+    },
+    {
+      "code": 6018,
+      "name": "TooLittleOutputReceived",
+      "msg": "Too little output received"
+    },
+    {
+      "code": 6019,
+      "name": "TooMuchInputPaid",
+      "msg": "Too much input paid"
+    },
+    {
+      "code": 6020,
+      "name": "ZeroAmountSpecified",
+      "msg": "Swap special amount can not be zero"
+    },
+    {
+      "code": 6021,
+      "name": "InvalidInputPoolVault",
+      "msg": "Input pool vault is invalid"
+    },
+    {
+      "code": 6022,
+      "name": "TooSmallInputOrOutputAmount",
+      "msg": "Swap input or output amount is too small"
+    },
+    {
+      "code": 6023,
+      "name": "NotEnoughTickArrayAccount",
+      "msg": "Not enough tick array account"
+    },
+    {
+      "code": 6024,
+      "name": "InvalidFirstTickArrayAccount",
+      "msg": "Invalid first tick array account"
+    },
+    {
+      "code": 6025,
+      "name": "InvalidRewardIndex",
+      "msg": "Invalid reward index"
+    },
+    {
+      "code": 6026,
+      "name": "FullRewardInfo",
+      "msg": "The init reward token reach to the max"
+    },
+    {
+      "code": 6027,
+      "name": "RewardTokenAlreadyInUse",
+      "msg": "The init reward token already in use"
+    },
+    {
+      "code": 6028,
+      "name": "ExceptRewardMint",
+      "msg": "The reward tokens must contain one of pool vault mint except the last reward"
+    },
+    {
+      "code": 6029,
+      "name": "InvalidRewardInitParam",
+      "msg": "Invalid reward init param"
+    },
+    {
+      "code": 6030,
+      "name": "InvalidRewardInputAccountNumber",
+      "msg": "Invalid collect reward input account number"
+    },
+    {
+      "code": 6031,
+      "name": "InvalidRewardPeriod",
+      "msg": "Invalid reward period"
+    },
+    {
+      "code": 6032,
+      "name": "NotApproveUpdateRewardEmissions",
+      "msg": "Modification of emissions is allowed within 72 hours from the end of the previous cycle"
+    },
+    {
+      "code": 6033,
+      "name": "UnInitializedRewardInfo",
+      "msg": "uninitialized reward info"
+    },
+    {
+      "code": 6034,
+      "name": "NotSupportMint",
+      "msg": "Not support token_2022 mint extension"
+    },
+    {
+      "code": 6035,
+      "name": "MissingTickArrayBitmapExtensionAccount",
+      "msg": "Missing tickarray bitmap extension account"
+    },
+    {
+      "code": 6036,
+      "name": "InsufficientLiquidityForDirection",
+      "msg": "Insufficient liquidity for this direction"
+    },
+    {
+      "code": 6037,
+      "name": "MaxTokenOverflow",
+      "msg": "Max token overflow"
+    },
+    {
+      "code": 6038,
+      "name": "CalculateOverflow",
+      "msg": "Calculate overflow"
+    },
+    {
+      "code": 6039,
+      "name": "TransferFeeCalculateNotMatch",
+      "msg": "TransferFee calculate not match"
+    },
+    {
+      "code": 6040,
+      "name": "OrderAlreadyFilled",
+      "msg": "Order already fully filled, cannot modify"
+    },
+    {
+      "code": 6041,
+      "name": "InvalidOrderPhase",
+      "msg": "Invalid order phase"
+    },
+    {
+      "code": 6042,
+      "name": "InvalidLimitOrderAmount",
+      "msg": "Invalid limit order amount"
+    },
+    {
+      "code": 6043,
+      "name": "OrderPhaseSaturated",
+      "msg": "Tick order phase saturated"
+    },
+    {
+      "code": 6044,
+      "name": "InvalidDynamicFeeConfigParams",
+      "msg": "Invalid dynamic fee config params"
+    },
+    {
+      "code": 6045,
+      "name": "InvalidFeeOn",
+      "msg": "Invalid fee on which token (must be 0, 1, or 2)"
+    },
+    {
+      "code": 6046,
+      "name": "ZeroSqrtPrice",
+      "msg": "sqrt_price_x64 must be greater than 0"
+    },
+    {
+      "code": 6047,
+      "name": "ZeroLiquidity",
+      "msg": "liquidity must be greater than 0"
+    },
+    {
+      "code": 6048,
+      "name": "MissingBaseFlag",
+      "msg": "base_flag is required when liquidity is zero"
+    },
+    {
+      "code": 6049,
+      "name": "MissingMintAccount",
+      "msg": "Mint account is required but not provided"
+    },
+    {
+      "code": 6050,
+      "name": "MissingTokenProgram2022",
+      "msg": "Token-2022 program is required but not provided"
+    }
+  ],
+  "types": [
     {
       "name": "AmmConfig",
       "docs": [
@@ -2468,43 +4701,46 @@
             "docs": [
               "Address of the protocol owner"
             ],
-            "type": "publicKey"
+            "type": "pubkey"
           },
           {
-            "name": "protocolFeeRate",
+            "name": "protocol_fee_rate",
             "docs": [
               "The protocol fee"
             ],
             "type": "u32"
           },
           {
-            "name": "tradeFeeRate",
+            "name": "trade_fee_rate",
             "docs": [
               "The trade fee, denominated in hundredths of a bip (10^-6)"
             ],
             "type": "u32"
           },
           {
-            "name": "tickSpacing",
+            "name": "tick_spacing",
             "docs": [
               "The tick spacing"
             ],
             "type": "u16"
           },
           {
-            "name": "fundFeeRate",
+            "name": "fund_fee_rate",
             "docs": [
               "The fund fee, denominated in hundredths of a bip (10^-6)"
             ],
             "type": "u32"
           },
           {
-            "name": "paddingU32",
+            "name": "padding_u32",
             "type": "u32"
           },
           {
-            "name": "fundOwner",
-            "type": "publicKey"
+            "name": "fund_owner",
+            "docs": [
+              "The fund owner"
+            ],
+            "type": "pubkey"
           },
           {
             "name": "padding",
@@ -2519,41 +4755,948 @@
       }
     },
     {
-      "name": "OperationState",
+      "name": "CollectFeeOn",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "FromInput"
+          },
+          {
+            "name": "Token0Only"
+          },
+          {
+            "name": "Token1Only"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CollectPersonalFeeEvent",
       "docs": [
-        "Holds the current owner of the factory"
+        "Emitted when tokens are collected for a position"
       ],
       "type": {
         "kind": "struct",
         "fields": [
           {
-            "name": "bump",
+            "name": "position_nft_mint",
             "docs": [
-              "Bump to identify PDA"
+              "The ID of the token for which underlying tokens were collected"
             ],
-            "type": "u8"
+            "type": "pubkey"
           },
           {
-            "name": "operationOwners",
+            "name": "recipient_token_account_0",
             "docs": [
-              "Address of the operation owner"
+              "The token account that received the collected token_0 tokens"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "recipient_token_account_1",
+            "docs": [
+              "The token account that received the collected token_1 tokens"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "amount_0",
+            "docs": [
+              "The amount of token_0 owed to the position that was collected"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "amount_1",
+            "docs": [
+              "The amount of token_1 owed to the position that was collected"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CollectProtocolFeeEvent",
+      "docs": [
+        "Emitted when the collected protocol fees are withdrawn by the factory owner"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_state",
+            "docs": [
+              "The pool whose protocol fee is collected"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "recipient_token_account_0",
+            "docs": [
+              "The address that receives the collected token_0 protocol fees"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "recipient_token_account_1",
+            "docs": [
+              "The address that receives the collected token_1 protocol fees"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "amount_0",
+            "docs": [
+              "The amount of token_0 protocol fees that is withdrawn"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "amount_1",
+            "docs": [
+              "The amount of token_0 protocol fees that is withdrawn"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConfigChangeEvent",
+      "docs": [
+        "Emitted when create or update a config"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "index",
+            "type": "u16"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "protocol_fee_rate",
+            "type": "u32"
+          },
+          {
+            "name": "trade_fee_rate",
+            "type": "u32"
+          },
+          {
+            "name": "tick_spacing",
+            "type": "u16"
+          },
+          {
+            "name": "fund_fee_rate",
+            "type": "u32"
+          },
+          {
+            "name": "fund_owner",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreateCustomizableParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "sqrt_price_x64",
+            "type": "u128"
+          },
+          {
+            "name": "collect_fee_on",
+            "type": {
+              "defined": {
+                "name": "CollectFeeOn"
+              }
+            }
+          },
+          {
+            "name": "enable_dynamic_fee",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreatePersonalPositionEvent",
+      "docs": [
+        "Emitted when create a new position"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_state",
+            "docs": [
+              "The pool for which liquidity was added"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "minter",
+            "docs": [
+              "The address that create the position"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "nft_owner",
+            "docs": [
+              "The owner of the position and recipient of any minted liquidity"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "tick_lower_index",
+            "docs": [
+              "The lower tick of the position"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "tick_upper_index",
+            "docs": [
+              "The upper tick of the position"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "liquidity",
+            "docs": [
+              "The amount of liquidity minted to the position range"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "deposit_amount_0",
+            "docs": [
+              "The amount of token_0 was deposit for the liquidity"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "deposit_amount_1",
+            "docs": [
+              "The amount of token_1 was deposit for the liquidity"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "deposit_amount_0_transfer_fee",
+            "docs": [
+              "The token transfer fee for deposit_amount_0"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "deposit_amount_1_transfer_fee",
+            "docs": [
+              "The token transfer fee for deposit_amount_1"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DecreaseLimitOrderEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_id",
+            "docs": [
+              "The pool whose limit order was decreased"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "limit_order",
+            "docs": [
+              "The limit order account"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "zero_for_one",
+            "docs": [
+              "Direction of the limit order (true if zero_for_one)"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "tick_index",
+            "docs": [
+              "Tick index of the limit order"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "total_amount",
+            "docs": [
+              "Total amount of the limit order"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "filled_amount",
+            "docs": [
+              "Filled amount of the limit order"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "settled_output_amount",
+            "docs": [
+              "Amount of output tokens settled (excluding fees)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "decreased_amount",
+            "docs": [
+              "Amount of input tokens returned to user"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DecreaseLiquidityEvent",
+      "docs": [
+        "Emitted when liquidity is decreased."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "position_nft_mint",
+            "docs": [
+              "The ID of the token for which liquidity was decreased"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "liquidity",
+            "docs": [
+              "The amount by which liquidity for the position was decreased"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "decrease_amount_0",
+            "docs": [
+              "The amount of token_0 that was paid for the decrease in liquidity"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "decrease_amount_1",
+            "docs": [
+              "The amount of token_1 that was paid for the decrease in liquidity"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "fee_amount_0",
+            "type": "u64"
+          },
+          {
+            "name": "fee_amount_1",
+            "docs": [
+              "The amount of token_1 fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "reward_amounts",
+            "docs": [
+              "The amount of rewards"
             ],
             "type": {
               "array": [
-                "publicKey",
-                10
+                "u64",
+                3
               ]
             }
           },
           {
-            "name": "whitelistMints",
+            "name": "transfer_fee_0",
             "docs": [
-              "The mint address of whitelist to emmit reward"
+              "The amount of token_0 transfer fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "transfer_fee_1",
+            "docs": [
+              "The amount of token_1 transfer fee"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DynamicFeeConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "index",
+            "type": "u16"
+          },
+          {
+            "name": "filter_period",
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "type": "u16"
+          },
+          {
+            "name": "dynamic_fee_control",
+            "type": "u32"
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "type": "u32"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                8
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "DynamicFeeInfo",
+      "docs": [
+        "Dynamic fee information for pool configuration"
+      ],
+      "serialization": "bytemuckunsafe",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "filter_period",
+            "docs": [
+              "Period that determines the high frequency trading time window (in seconds)."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "docs": [
+              "Period that determines when the dynamic fee starts to decrease (in seconds)."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "docs": [
+              "Dynamic fee rate decrement rate, used for volatility reference decay."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "dynamic_fee_control",
+            "docs": [
+              "Factor used to scale the dynamic fee component in the fee rate calculation."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "docs": [
+              "Maximum value for the volatility accumulator, used to cap the dynamic fee rate."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "tick_spacing_index_reference",
+            "docs": [
+              "Active tick spacing index at the last reference update."
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "volatility_reference",
+            "docs": [
+              "Volatility reference value, stores the decayed volatility accumulator."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "volatility_accumulator",
+            "docs": [
+              "Volatility accumulator, used to calculate the dynamic fee rate."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "last_update_timestamp",
+            "docs": [
+              "Last timestamp (block time) when `volatility_reference` and `tick_spacing_index_reference` were updated."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "Reserved for future upgrades."
             ],
             "type": {
               "array": [
-                "publicKey",
-                100
+                "u8",
+                46
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "IncreaseLimitOrderEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_id",
+            "docs": [
+              "The pool whose limit order was increased"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "limit_order",
+            "docs": [
+              "The limit order account"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "zero_for_one",
+            "docs": [
+              "Direction of the limit order (true if zero_for_one)"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "tick_index",
+            "docs": [
+              "Tick index of the limit order"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "total_amount",
+            "docs": [
+              "Total amount of the limit order"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "increased_amount",
+            "docs": [
+              "Increased amount of the limit order"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "transfer_fee",
+            "docs": [
+              "Transfer fee of the limit order"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "IncreaseLiquidityEvent",
+      "docs": [
+        "Emitted when liquidity is increased."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "position_nft_mint",
+            "docs": [
+              "The ID of the token for which liquidity was increased"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "liquidity",
+            "docs": [
+              "The amount by which liquidity for the NFT position was increased"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "amount_0",
+            "docs": [
+              "The amount of token_0 that was paid for the increase in liquidity"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "amount_1",
+            "docs": [
+              "The amount of token_1 that was paid for the increase in liquidity"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "amount_0_transfer_fee",
+            "docs": [
+              "The token transfer fee for amount_0"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "amount_1_transfer_fee",
+            "docs": [
+              "The token transfer fee for amount_1"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "InitializeRewardParam",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "open_time",
+            "docs": [
+              "Reward open time"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "end_time",
+            "docs": [
+              "Reward end time"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "emissions_per_second_x64",
+            "docs": [
+              "Token reward per second are earned per unit of liquidity"
+            ],
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LimitOrderNonce",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "user_wallet",
+            "type": "pubkey"
+          },
+          {
+            "name": "nonce_index",
+            "type": "u8"
+          },
+          {
+            "name": "order_nonce",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                4
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LimitOrderState",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_id",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "docs": [
+              "Owner of this limit order"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "tick_index",
+            "type": "i32"
+          },
+          {
+            "name": "zero_for_one",
+            "type": "bool"
+          },
+          {
+            "name": "order_phase",
+            "docs": [
+              "Order phase of this limit order, aligned with `TickState.order_phase` for FIFO semantics"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_amount",
+            "docs": [
+              "Total amount of the limit order"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "filled_amount",
+            "docs": [
+              "Filled amount of the limit order (informational, for events/display)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "settle_base",
+            "docs": [
+              "The unfilled amount when the current computation segment started.",
+              "Set to total_amount on open, reset on decrease. Never updated during settle —",
+              "this avoids cascading floor-division error across multiple settles."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "settled_output",
+            "docs": [
+              "Cumulative output paid to user in the current segment. Reset on decrease.",
+              "Each settle computes total_output from the segment base and pays the diff",
+              "(total_output - settled_output), limiting dust deduction to once per segment."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "open_time",
+            "docs": [
+              "Order open time"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "unfilled_ratio_x64",
+            "docs": [
+              "Snapshot of `TickState.unfilled_ratio_x64` at the time this segment started (Q64.64).",
+              "Initialized to Q64 on open; reset to tick's current ratio on decrease."
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                4
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityCalculateEvent",
+      "docs": [
+        "Emitted when liquidity decreased or increase."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_liquidity",
+            "docs": [
+              "The pool liquidity before decrease or increase"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "pool_sqrt_price_x64",
+            "docs": [
+              "The pool price when decrease or increase in liquidity"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "pool_tick",
+            "docs": [
+              "The pool tick when decrease or increase in liquidity"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "calc_amount_0",
+            "docs": [
+              "The amount of token_0 that was calculated for the decrease or increase in liquidity"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "calc_amount_1",
+            "docs": [
+              "The amount of token_1 that was calculated for the decrease or increase in liquidity"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "trade_fee_owed_0",
+            "type": "u64"
+          },
+          {
+            "name": "trade_fee_owed_1",
+            "docs": [
+              "The amount of token_1 fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "transfer_fee_0",
+            "docs": [
+              "The amount of token_0 transfer fee without trade_fee_amount_0"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "transfer_fee_1",
+            "docs": [
+              "The amount of token_1 transfer fee without trade_fee_amount_0"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityChangeEvent",
+      "docs": [
+        "Emitted pool liquidity change when increase and decrease liquidity"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_state",
+            "docs": [
+              "The pool for swap"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "tick",
+            "docs": [
+              "The tick of the pool"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "tick_lower",
+            "docs": [
+              "The tick lower of position"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "tick_upper",
+            "docs": [
+              "The tick lower of position"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "liquidity_before",
+            "docs": [
+              "The liquidity of the pool before liquidity change"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "liquidity_after",
+            "docs": [
+              "The liquidity of the pool after liquidity change"
+            ],
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Observation",
+      "docs": [
+        "The element of observations in ObservationState"
+      ],
+      "serialization": "bytemuckunsafe",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "block_timestamp",
+            "docs": [
+              "The block timestamp of the observation"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "tick_cumulative",
+            "docs": [
+              "the cumulative of tick during the duration time"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding for feature update"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                4
               ]
             }
           }
@@ -2562,6 +5705,11 @@
     },
     {
       "name": "ObservationState",
+      "serialization": "bytemuckunsafe",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
       "type": {
         "kind": "struct",
         "fields": [
@@ -2573,25 +5721,25 @@
             "type": "bool"
           },
           {
-            "name": "recentEpoch",
+            "name": "recent_epoch",
             "docs": [
               "recent update epoch"
             ],
             "type": "u64"
           },
           {
-            "name": "observationIndex",
+            "name": "observation_index",
             "docs": [
               "the most-recently updated index of the observations array"
             ],
             "type": "u16"
           },
           {
-            "name": "poolId",
+            "name": "pool_id",
             "docs": [
               "belongs to which pool"
             ],
-            "type": "publicKey"
+            "type": "pubkey"
           },
           {
             "name": "observations",
@@ -2601,7 +5749,9 @@
             "type": {
               "array": [
                 {
-                  "defined": "Observation"
+                  "defined": {
+                    "name": "Observation"
+                  }
                 },
                 100
               ]
@@ -2616,6 +5766,106 @@
               "array": [
                 "u64",
                 4
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "OpenLimitOrderEvent",
+      "docs": [
+        "Emitted when a limit order is opened"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_id",
+            "docs": [
+              "The pool whose limit order was opened"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "limit_order",
+            "docs": [
+              "The limit order account"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "zero_for_one",
+            "docs": [
+              "Direction of the limit order (true if zero_for_one)"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "tick_index",
+            "docs": [
+              "Tick index of the limit order"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "total_amount",
+            "docs": [
+              "Total amount of the limit order"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "transfer_fee",
+            "docs": [
+              "Transfer fee of the limit order"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OperationState",
+      "docs": [
+        "Holds the current owner of the factory"
+      ],
+      "serialization": "bytemuckunsafe",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "docs": [
+              "Bump to identify PDA"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "operation_owners",
+            "docs": [
+              "Address of the operation owner"
+            ],
+            "type": {
+              "array": [
+                "pubkey",
+                10
+              ]
+            }
+          },
+          {
+            "name": "whitelist_mints",
+            "docs": [
+              "The mint address of whitelist to emit reward"
+            ],
+            "type": {
+              "array": [
+                "pubkey",
+                100
               ]
             }
           }
@@ -2640,28 +5890,28 @@
             }
           },
           {
-            "name": "nftMint",
+            "name": "nft_mint",
             "docs": [
               "Mint address of the tokenized position"
             ],
-            "type": "publicKey"
+            "type": "pubkey"
           },
           {
-            "name": "poolId",
+            "name": "pool_id",
             "docs": [
               "The ID of the pool with which this token is connected"
             ],
-            "type": "publicKey"
+            "type": "pubkey"
           },
           {
-            "name": "tickLowerIndex",
+            "name": "tick_lower_index",
             "docs": [
               "The lower bound tick of the position"
             ],
             "type": "i32"
           },
           {
-            "name": "tickUpperIndex",
+            "name": "tick_upper_index",
             "docs": [
               "The upper bound tick of the position"
             ],
@@ -2675,46 +5925,48 @@
             "type": "u128"
           },
           {
-            "name": "feeGrowthInside0LastX64",
+            "name": "fee_growth_inside_0_last_x64",
             "docs": [
               "The token_0 fee growth of the aggregate position as of the last action on the individual position"
             ],
             "type": "u128"
           },
           {
-            "name": "feeGrowthInside1LastX64",
+            "name": "fee_growth_inside_1_last_x64",
             "docs": [
               "The token_1 fee growth of the aggregate position as of the last action on the individual position"
             ],
             "type": "u128"
           },
           {
-            "name": "tokenFeesOwed0",
+            "name": "token_fees_owed_0",
             "docs": [
               "The fees owed to the position owner in token_0, as of the last computation"
             ],
             "type": "u64"
           },
           {
-            "name": "tokenFeesOwed1",
+            "name": "token_fees_owed_1",
             "docs": [
               "The fees owed to the position owner in token_1, as of the last computation"
             ],
             "type": "u64"
           },
           {
-            "name": "rewardInfos",
+            "name": "reward_infos",
             "type": {
               "array": [
                 {
-                  "defined": "PositionRewardInfo"
+                  "defined": {
+                    "name": "PositionRewardInfo"
+                  }
                 },
                 3
               ]
             }
           },
           {
-            "name": "recentEpoch",
+            "name": "recent_epoch",
             "type": "u64"
           },
           {
@@ -2730,6 +5982,74 @@
       }
     },
     {
+      "name": "PoolCreatedEvent",
+      "docs": [
+        "Emitted when a pool is created and initialized with a starting price",
+        ""
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "token_mint_0",
+            "docs": [
+              "The first token of the pool by address sort order"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_mint_1",
+            "docs": [
+              "The second token of the pool by address sort order"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "tick_spacing",
+            "docs": [
+              "The minimum number of ticks between initialized ticks"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "pool_state",
+            "docs": [
+              "The address of the created pool"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "sqrt_price_x64",
+            "docs": [
+              "The initial sqrt price of the pool, as a Q64.64"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "tick",
+            "docs": [
+              "The initial tick of the pool, i.e. log base 1.0001 of the starting price of the pool"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "token_vault_0",
+            "docs": [
+              "Vault of token_0"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_vault_1",
+            "docs": [
+              "Vault of token_1"
+            ],
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
       "name": "PoolState",
       "docs": [
         "The pool state",
@@ -2737,6 +6057,11 @@
         "PDA of `[POOL_SEED, config, token_mint_0, token_mint_1]`",
         ""
       ],
+      "serialization": "bytemuckunsafe",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
       "type": {
         "kind": "struct",
         "fields": [
@@ -2753,55 +6078,55 @@
             }
           },
           {
-            "name": "ammConfig",
-            "type": "publicKey"
+            "name": "amm_config",
+            "type": "pubkey"
           },
           {
             "name": "owner",
-            "type": "publicKey"
+            "type": "pubkey"
           },
           {
-            "name": "tokenMint0",
+            "name": "token_mint_0",
             "docs": [
               "Token pair of the pool, where token_mint_0 address < token_mint_1 address"
             ],
-            "type": "publicKey"
+            "type": "pubkey"
           },
           {
-            "name": "tokenMint1",
-            "type": "publicKey"
+            "name": "token_mint_1",
+            "type": "pubkey"
           },
           {
-            "name": "tokenVault0",
+            "name": "token_vault_0",
             "docs": [
               "Token pair vault"
             ],
-            "type": "publicKey"
+            "type": "pubkey"
           },
           {
-            "name": "tokenVault1",
-            "type": "publicKey"
+            "name": "token_vault_1",
+            "type": "pubkey"
           },
           {
-            "name": "observationKey",
+            "name": "observation_key",
             "docs": [
               "observation account key"
             ],
-            "type": "publicKey"
+            "type": "pubkey"
           },
           {
-            "name": "mintDecimals0",
+            "name": "mint_decimals_0",
             "docs": [
               "mint0 and mint1 decimals"
             ],
             "type": "u8"
           },
           {
-            "name": "mintDecimals1",
+            "name": "mint_decimals_1",
             "type": "u8"
           },
           {
-            "name": "tickSpacing",
+            "name": "tick_spacing",
             "docs": [
               "The minimum number of ticks between initialized ticks"
             ],
@@ -2815,14 +6140,14 @@
             "type": "u128"
           },
           {
-            "name": "sqrtPriceX64",
+            "name": "sqrt_price_x64",
             "docs": [
               "The current price of the pool as a sqrt(token_1/token_0) Q64.64 value"
             ],
             "type": "u128"
           },
           {
-            "name": "tickCurrent",
+            "name": "tick_current",
             "docs": [
               "The current tick of the pool, i.e. according to the last tick transition that was run."
             ],
@@ -2837,7 +6162,7 @@
             "type": "u16"
           },
           {
-            "name": "feeGrowthGlobal0X64",
+            "name": "fee_growth_global_0_x64",
             "docs": [
               "The fee growth as a Q64.64 number, i.e. fees of token_0 and token_1 collected per",
               "unit of liquidity for the entire life of the pool."
@@ -2845,38 +6170,28 @@
             "type": "u128"
           },
           {
-            "name": "feeGrowthGlobal1X64",
+            "name": "fee_growth_global_1_x64",
             "type": "u128"
           },
           {
-            "name": "protocolFeesToken0",
+            "name": "protocol_fees_token_0",
             "docs": [
               "The amounts of token_0 and token_1 that are owed to the protocol."
             ],
             "type": "u64"
           },
           {
-            "name": "protocolFeesToken1",
+            "name": "protocol_fees_token_1",
             "type": "u64"
           },
           {
-            "name": "swapInAmountToken0",
-            "docs": [
-              "The amounts in and out of swap token_0 and token_1"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "swapOutAmountToken1",
-            "type": "u128"
-          },
-          {
-            "name": "swapInAmountToken1",
-            "type": "u128"
-          },
-          {
-            "name": "swapOutAmountToken0",
-            "type": "u128"
+            "name": "padding5",
+            "type": {
+              "array": [
+                "u128",
+                4
+              ]
+            }
           },
           {
             "name": "status",
@@ -2886,7 +6201,15 @@
               "bit1, 1: disable decrease liquidity, 0: normal",
               "bit2, 1: disable collect fee, 0: normal",
               "bit3, 1: disable collect reward, 0: normal",
-              "bit4, 1: disable swap, 0: normal"
+              "bit4, 1: disable swap, 0: normal",
+              "bit5, 1: disable limit order, 0: normal"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "fee_on",
+            "docs": [
+              "Fee on which token (0 = FromInput, 1 = Token0Only, 2 = Token1Only)"
             ],
             "type": "u8"
           },
@@ -2898,23 +6221,25 @@
             "type": {
               "array": [
                 "u8",
-                7
+                6
               ]
             }
           },
           {
-            "name": "rewardInfos",
+            "name": "reward_infos",
             "type": {
               "array": [
                 {
-                  "defined": "RewardInfo"
+                  "defined": {
+                    "name": "RewardInfo"
+                  }
                 },
                 3
               ]
             }
           },
           {
-            "name": "tickArrayBitmap",
+            "name": "tick_array_bitmap",
             "docs": [
               "Packed initialized tick array state"
             ],
@@ -2926,49 +6251,47 @@
             }
           },
           {
-            "name": "totalFeesToken0",
+            "name": "padding6",
+            "type": {
+              "array": [
+                "u64",
+                4
+              ]
+            }
+          },
+          {
+            "name": "fund_fees_token_0",
+            "type": "u64"
+          },
+          {
+            "name": "fund_fees_token_1",
+            "type": "u64"
+          },
+          {
+            "name": "open_time",
+            "type": "u64"
+          },
+          {
+            "name": "recent_epoch",
+            "type": "u64"
+          },
+          {
+            "name": "dynamic_fee_info",
             "docs": [
-              "except protocol_fee and fund_fee"
+              "Dynamic fee info"
             ],
-            "type": "u64"
-          },
-          {
-            "name": "totalFeesClaimedToken0",
-            "docs": [
-              "except protocol_fee and fund_fee"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "totalFeesToken1",
-            "type": "u64"
-          },
-          {
-            "name": "totalFeesClaimedToken1",
-            "type": "u64"
-          },
-          {
-            "name": "fundFeesToken0",
-            "type": "u64"
-          },
-          {
-            "name": "fundFeesToken1",
-            "type": "u64"
-          },
-          {
-            "name": "openTime",
-            "type": "u64"
-          },
-          {
-            "name": "recentEpoch",
-            "type": "u64"
+            "type": {
+              "defined": {
+                "name": "DynamicFeeInfo"
+              }
+            }
           },
           {
             "name": "padding1",
             "type": {
               "array": [
                 "u64",
-                24
+                14
               ]
             }
           },
@@ -2980,6 +6303,22 @@
                 32
               ]
             }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PositionRewardInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "growth_inside_last_x64",
+            "type": "u128"
+          },
+          {
+            "name": "reward_amount_owed",
+            "type": "u64"
           }
         ]
       }
@@ -3000,21 +6339,21 @@
             "type": "u8"
           },
           {
-            "name": "poolId",
+            "name": "pool_id",
             "docs": [
               "The ID of the pool with which this token is connected"
             ],
-            "type": "publicKey"
+            "type": "pubkey"
           },
           {
-            "name": "tickLowerIndex",
+            "name": "tick_lower_index",
             "docs": [
               "The lower bound tick of the position"
             ],
             "type": "i32"
           },
           {
-            "name": "tickUpperIndex",
+            "name": "tick_upper_index",
             "docs": [
               "The upper bound tick of the position"
             ],
@@ -3028,35 +6367,35 @@
             "type": "u128"
           },
           {
-            "name": "feeGrowthInside0LastX64",
+            "name": "fee_growth_inside_0_last_x64",
             "docs": [
               "The token_0 fee growth per unit of liquidity as of the last update to liquidity or fees owed"
             ],
             "type": "u128"
           },
           {
-            "name": "feeGrowthInside1LastX64",
+            "name": "fee_growth_inside_1_last_x64",
             "docs": [
               "The token_1 fee growth per unit of liquidity as of the last update to liquidity or fees owed"
             ],
             "type": "u128"
           },
           {
-            "name": "tokenFeesOwed0",
+            "name": "token_fees_owed_0",
             "docs": [
               "The fees owed to the position owner in token_0"
             ],
             "type": "u64"
           },
           {
-            "name": "tokenFeesOwed1",
+            "name": "token_fees_owed_1",
             "docs": [
               "The fees owed to the position owner in token_1"
             ],
             "type": "u64"
           },
           {
-            "name": "rewardGrowthInside",
+            "name": "reward_growth_inside",
             "docs": [
               "The reward growth per unit of liquidity as of the last update to liquidity"
             ],
@@ -3068,7 +6407,7 @@
             }
           },
           {
-            "name": "recentEpoch",
+            "name": "recent_epoch",
             "type": "u64"
           },
           {
@@ -3084,43 +6423,184 @@
       }
     },
     {
-      "name": "TickArrayState",
+      "name": "RewardInfo",
+      "serialization": "bytemuckunsafe",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
       "type": {
         "kind": "struct",
         "fields": [
           {
-            "name": "poolId",
-            "type": "publicKey"
-          },
-          {
-            "name": "startTickIndex",
-            "type": "i32"
-          },
-          {
-            "name": "ticks",
-            "type": {
-              "array": [
-                {
-                  "defined": "TickState"
-                },
-                60
-              ]
-            }
-          },
-          {
-            "name": "initializedTickCount",
+            "name": "reward_state",
+            "docs": [
+              "Reward state"
+            ],
             "type": "u8"
           },
           {
-            "name": "recentEpoch",
+            "name": "open_time",
+            "docs": [
+              "Reward open time"
+            ],
             "type": "u64"
+          },
+          {
+            "name": "end_time",
+            "docs": [
+              "Reward end time"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "last_update_time",
+            "docs": [
+              "Reward last update time"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "emissions_per_second_x64",
+            "docs": [
+              "Q64.64 number indicates how many tokens per second are earned per unit of liquidity."
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "reward_total_emitted",
+            "docs": [
+              "The total amount of reward emitted"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "reward_claimed",
+            "docs": [
+              "The total amount of claimed reward"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "token_mint",
+            "docs": [
+              "Reward token mint."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_vault",
+            "docs": [
+              "Reward vault token account."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "authority",
+            "docs": [
+              "The owner that has permission to set reward param"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_growth_global_x64",
+            "docs": [
+              "Q64.64 number that tracks the total tokens earned per unit of liquidity since the reward",
+              "emissions were turned on."
+            ],
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SettleLimitOrderEvent",
+      "docs": [
+        "Emitted when a limit order is settled and proceeds are transferred"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_id",
+            "docs": [
+              "The pool whose limit order was settled"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "limit_order",
+            "docs": [
+              "The limit order account"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "zero_for_one",
+            "docs": [
+              "Direction of the limit order (true if zero_for_one)"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "tick_index",
+            "docs": [
+              "Tick index of the limit order"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "total_amount",
+            "docs": [
+              "Total amount of the limit order"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "filled_amount",
+            "docs": [
+              "Filled amount of the limit order"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "settled_amount_out",
+            "docs": [
+              "Amount of output tokens transferred (excluding fees)"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SupportMintAssociated",
+      "docs": [
+        "Holds the current owner of the factory"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "docs": [
+              "Bump to identify PDA"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "mint",
+            "docs": [
+              "Address of the supported token22 mint"
+            ],
+            "type": "pubkey"
           },
           {
             "name": "padding",
             "type": {
               "array": [
-                "u8",
-                107
+                "u64",
+                8
               ]
             }
           }
@@ -3128,16 +6608,118 @@
       }
     },
     {
-      "name": "TickArrayBitmapExtension",
+      "name": "SwapEvent",
+      "docs": [
+        "Emitted by when a swap is performed for a pool"
+      ],
       "type": {
         "kind": "struct",
         "fields": [
           {
-            "name": "poolId",
-            "type": "publicKey"
+            "name": "pool_state",
+            "docs": [
+              "The pool for which token_0 and token_1 were swapped"
+            ],
+            "type": "pubkey"
           },
           {
-            "name": "positiveTickArrayBitmap",
+            "name": "sender",
+            "docs": [
+              "The address that initiated the swap call, and that received the callback"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_account_0",
+            "docs": [
+              "The payer token account in zero for one swaps, or the recipient token account",
+              "in one for zero swaps"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_account_1",
+            "docs": [
+              "The payer token account in one for zero swaps, or the recipient token account",
+              "in zero for one swaps"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "amount_0",
+            "docs": [
+              "The real delta amount of the token_0 of the pool or user"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "transfer_fee_0",
+            "docs": [
+              "The transfer fee charged by the withheld_amount of the token_0"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "amount_1",
+            "docs": [
+              "The real delta of the token_1 of the pool or user"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "transfer_fee_1",
+            "docs": [
+              "The transfer fee charged by the withheld_amount of the token_1"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "zero_for_one",
+            "docs": [
+              "if true, amount_0 is negtive and amount_1 is positive"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "sqrt_price_x64",
+            "docs": [
+              "The sqrt(price) of the pool after the swap, as a Q64.64"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "liquidity",
+            "docs": [
+              "The liquidity of the pool after the swap"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "tick",
+            "docs": [
+              "The log base 1.0001 of price of the pool after the swap"
+            ],
+            "type": "i32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TickArrayBitmapExtension",
+      "serialization": "bytemuckunsafe",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_id",
+            "type": "pubkey"
+          },
+          {
+            "name": "positive_tick_array_bitmap",
             "docs": [
               "Packed initialized tick array state for start_tick_index is positive"
             ],
@@ -3154,7 +6736,7 @@
             }
           },
           {
-            "name": "negativeTickArrayBitmap",
+            "name": "negative_tick_array_bitmap",
             "docs": [
               "Packed initialized tick array state for start_tick_index is negitive"
             ],
@@ -3172,69 +6754,52 @@
           }
         ]
       }
-    }
-  ],
-  "types": [
-    {
-      "name": "InitializeRewardParam",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "openTime",
-            "docs": [
-              "Reward open time"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "endTime",
-            "docs": [
-              "Reward end time"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "emissionsPerSecondX64",
-            "docs": [
-              "Token reward per second are earned per unit of liquidity"
-            ],
-            "type": "u128"
-          }
-        ]
-      }
     },
     {
-      "name": "Observation",
-      "docs": [
-        "The element of observations in ObservationState"
-      ],
+      "name": "TickArrayState",
+      "serialization": "bytemuckunsafe",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
       "type": {
         "kind": "struct",
         "fields": [
           {
-            "name": "blockTimestamp",
-            "docs": [
-              "The block timestamp of the observation"
-            ],
-            "type": "u32"
+            "name": "pool_id",
+            "type": "pubkey"
           },
           {
-            "name": "tickCumulative",
-            "docs": [
-              "the cumulative of tick during the duration time"
-            ],
-            "type": "i64"
+            "name": "start_tick_index",
+            "type": "i32"
+          },
+          {
+            "name": "ticks",
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "TickState"
+                  }
+                },
+                60
+              ]
+            }
+          },
+          {
+            "name": "initialized_tick_count",
+            "type": "u8"
+          },
+          {
+            "name": "recent_epoch",
+            "type": "u64"
           },
           {
             "name": "padding",
-            "docs": [
-              "padding for feature update"
-            ],
             "type": {
               "array": [
-                "u64",
-                4
+                "u8",
+                107
               ]
             }
           }
@@ -3242,109 +6807,12 @@
       }
     },
     {
-      "name": "PositionRewardInfo",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "growthInsideLastX64",
-            "type": "u128"
-          },
-          {
-            "name": "rewardAmountOwed",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "RewardInfo",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "rewardState",
-            "docs": [
-              "Reward state"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "openTime",
-            "docs": [
-              "Reward open time"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "endTime",
-            "docs": [
-              "Reward end time"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "lastUpdateTime",
-            "docs": [
-              "Reward last update time"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "emissionsPerSecondX64",
-            "docs": [
-              "Q64.64 number indicates how many tokens per second are earned per unit of liquidity."
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "rewardTotalEmissioned",
-            "docs": [
-              "The total amount of reward emissioned"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "rewardClaimed",
-            "docs": [
-              "The total amount of claimed reward"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "tokenMint",
-            "docs": [
-              "Reward token mint."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenVault",
-            "docs": [
-              "Reward vault token account."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "authority",
-            "docs": [
-              "The owner that has permission to set reward param"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "rewardGrowthGlobalX64",
-            "docs": [
-              "Q64.64 number that tracks the total tokens earned per unit of liquidity since the reward",
-              "emissions were turned on."
-            ],
-            "type": "u128"
-          }
-        ]
-      }
-    },
-    {
       "name": "TickState",
+      "serialization": "bytemuckunsafe",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
       "type": {
         "kind": "struct",
         "fields": [
@@ -3353,21 +6821,21 @@
             "type": "i32"
           },
           {
-            "name": "liquidityNet",
+            "name": "liquidity_net",
             "docs": [
               "Amount of net liquidity added (subtracted) when tick is crossed from left to right (right to left)"
             ],
             "type": "i128"
           },
           {
-            "name": "liquidityGross",
+            "name": "liquidity_gross",
             "docs": [
               "The total position liquidity that references this tick"
             ],
             "type": "u128"
           },
           {
-            "name": "feeGrowthOutside0X64",
+            "name": "fee_growth_outside_0_x64",
             "docs": [
               "Fee growth per unit of liquidity on the _other_ side of this tick (relative to the current tick)",
               "only has relative meaning, not absolute — the value depends on when the tick is initialized"
@@ -3375,11 +6843,14 @@
             "type": "u128"
           },
           {
-            "name": "feeGrowthOutside1X64",
+            "name": "fee_growth_outside_1_x64",
             "type": "u128"
           },
           {
-            "name": "rewardGrowthsOutsideX64",
+            "name": "reward_growths_outside_x64",
+            "docs": [
+              "Reward growth per unit of liquidity like fee, array of Q64.64"
+            ],
             "type": {
               "array": [
                 "u128",
@@ -3388,11 +6859,41 @@
             }
           },
           {
+            "name": "order_phase",
+            "docs": [
+              "Order phase of the tick, used as a FIFO cohort index for limit orders"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "orders_amount",
+            "docs": [
+              "The amount of limit orders that have never been matched,",
+              "only counts newly opened orders, not partially filled ones"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "part_filled_orders_remaining",
+            "docs": [
+              "Remaining part filled orders amount"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "unfilled_ratio_x64",
+            "docs": [
+              "Cumulative unfilled ratio for the current part-filled cohort (Q64.64 format).",
+              "Starts at Q64(1) when a new cohort forms, multiplied down as fills occur."
+            ],
+            "type": "u128"
+          },
+          {
             "name": "padding",
             "type": {
               "array": [
                 "u32",
-                13
+                3
               ]
             }
           }
@@ -3400,755 +6901,27 @@
       }
     },
     {
-      "name": "PoolStatusBitIndex",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "OpenPositionOrIncreaseLiquidity"
-          },
-          {
-            "name": "DecreaseLiquidity"
-          },
-          {
-            "name": "CollectFee"
-          },
-          {
-            "name": "CollectReward"
-          },
-          {
-            "name": "Swap"
-          }
-        ]
-      }
-    },
-    {
-      "name": "PoolStatusBitFlag",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Enable"
-          },
-          {
-            "name": "Disable"
-          }
-        ]
-      }
-    },
-    {
-      "name": "RewardState",
+      "name": "UpdateRewardInfosEvent",
       "docs": [
-        "State of reward"
+        "Emitted when Reward are updated for a pool"
       ],
       "type": {
-        "kind": "enum",
-        "variants": [
+        "kind": "struct",
+        "fields": [
           {
-            "name": "Uninitialized"
-          },
-          {
-            "name": "Initialized"
-          },
-          {
-            "name": "Opening"
-          },
-          {
-            "name": "Ended"
+            "name": "reward_growth_global_x64",
+            "docs": [
+              "Reward info"
+            ],
+            "type": {
+              "array": [
+                "u128",
+                3
+              ]
+            }
           }
         ]
       }
-    },
-    {
-      "name": "TickArryBitmap",
-      "type": {
-        "kind": "alias",
-        "value": {
-          "array": [
-            "u64",
-            8
-          ]
-        }
-      }
-    }
-  ],
-  "events": [
-    {
-      "name": "ConfigChangeEvent",
-      "fields": [
-        {
-          "name": "index",
-          "type": "u16",
-          "index": false
-        },
-        {
-          "name": "owner",
-          "type": "publicKey",
-          "index": true
-        },
-        {
-          "name": "protocolFeeRate",
-          "type": "u32",
-          "index": false
-        },
-        {
-          "name": "tradeFeeRate",
-          "type": "u32",
-          "index": false
-        },
-        {
-          "name": "tickSpacing",
-          "type": "u16",
-          "index": false
-        },
-        {
-          "name": "fundFeeRate",
-          "type": "u32",
-          "index": false
-        },
-        {
-          "name": "fundOwner",
-          "type": "publicKey",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "CreatePersonalPositionEvent",
-      "fields": [
-        {
-          "name": "poolState",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "minter",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "nftOwner",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "tickLowerIndex",
-          "type": "i32",
-          "index": false
-        },
-        {
-          "name": "tickUpperIndex",
-          "type": "i32",
-          "index": false
-        },
-        {
-          "name": "liquidity",
-          "type": "u128",
-          "index": false
-        },
-        {
-          "name": "depositAmount0",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "depositAmount1",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "depositAmount0TransferFee",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "depositAmount1TransferFee",
-          "type": "u64",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "IncreaseLiquidityEvent",
-      "fields": [
-        {
-          "name": "positionNftMint",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "liquidity",
-          "type": "u128",
-          "index": false
-        },
-        {
-          "name": "amount0",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "amount1",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "amount0TransferFee",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "amount1TransferFee",
-          "type": "u64",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "DecreaseLiquidityEvent",
-      "fields": [
-        {
-          "name": "positionNftMint",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "liquidity",
-          "type": "u128",
-          "index": false
-        },
-        {
-          "name": "decreaseAmount0",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "decreaseAmount1",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "feeAmount0",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "feeAmount1",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "rewardAmounts",
-          "type": {
-            "array": [
-              "u64",
-              3
-            ]
-          },
-          "index": false
-        },
-        {
-          "name": "transferFee0",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "transferFee1",
-          "type": "u64",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "LiquidityCalculateEvent",
-      "fields": [
-        {
-          "name": "poolLiquidity",
-          "type": "u128",
-          "index": false
-        },
-        {
-          "name": "poolSqrtPriceX64",
-          "type": "u128",
-          "index": false
-        },
-        {
-          "name": "poolTick",
-          "type": "i32",
-          "index": false
-        },
-        {
-          "name": "calcAmount0",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "calcAmount1",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "tradeFeeOwed0",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "tradeFeeOwed1",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "transferFee0",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "transferFee1",
-          "type": "u64",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "CollectPersonalFeeEvent",
-      "fields": [
-        {
-          "name": "positionNftMint",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "recipientTokenAccount0",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "recipientTokenAccount1",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "amount0",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "amount1",
-          "type": "u64",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "UpdateRewardInfosEvent",
-      "fields": [
-        {
-          "name": "rewardGrowthGlobalX64",
-          "type": {
-            "array": [
-              "u128",
-              3
-            ]
-          },
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "PoolCreatedEvent",
-      "fields": [
-        {
-          "name": "tokenMint0",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "tokenMint1",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "tickSpacing",
-          "type": "u16",
-          "index": false
-        },
-        {
-          "name": "poolState",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "sqrtPriceX64",
-          "type": "u128",
-          "index": false
-        },
-        {
-          "name": "tick",
-          "type": "i32",
-          "index": false
-        },
-        {
-          "name": "tokenVault0",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "tokenVault1",
-          "type": "publicKey",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "CollectProtocolFeeEvent",
-      "fields": [
-        {
-          "name": "poolState",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "recipientTokenAccount0",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "recipientTokenAccount1",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "amount0",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "amount1",
-          "type": "u64",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "SwapEvent",
-      "fields": [
-        {
-          "name": "poolState",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "sender",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "tokenAccount0",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "tokenAccount1",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "amount0",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "transferFee0",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "amount1",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "transferFee1",
-          "type": "u64",
-          "index": false
-        },
-        {
-          "name": "zeroForOne",
-          "type": "bool",
-          "index": false
-        },
-        {
-          "name": "sqrtPriceX64",
-          "type": "u128",
-          "index": false
-        },
-        {
-          "name": "liquidity",
-          "type": "u128",
-          "index": false
-        },
-        {
-          "name": "tick",
-          "type": "i32",
-          "index": false
-        }
-      ]
-    },
-    {
-      "name": "LiquidityChangeEvent",
-      "fields": [
-        {
-          "name": "poolState",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "tick",
-          "type": "i32",
-          "index": false
-        },
-        {
-          "name": "tickLower",
-          "type": "i32",
-          "index": false
-        },
-        {
-          "name": "tickUpper",
-          "type": "i32",
-          "index": false
-        },
-        {
-          "name": "liquidityBefore",
-          "type": "u128",
-          "index": false
-        },
-        {
-          "name": "liquidityAfter",
-          "type": "u128",
-          "index": false
-        }
-      ]
-    }
-  ],
-  "errors": [
-    {
-      "code": 6000,
-      "name": "LOK",
-      "msg": "LOK"
-    },
-    {
-      "code": 6001,
-      "name": "NotApproved",
-      "msg": "Not approved"
-    },
-    {
-      "code": 6002,
-      "name": "InvalidUpdateConfigFlag",
-      "msg": "invalid update amm config flag"
-    },
-    {
-      "code": 6003,
-      "name": "AccountLack",
-      "msg": "Account lack"
-    },
-    {
-      "code": 6004,
-      "name": "ClosePositionErr",
-      "msg": "Remove liquitity, collect fees owed and reward then you can close position account"
-    },
-    {
-      "code": 6005,
-      "name": "ZeroMintAmount",
-      "msg": "Minting amount should be greater than 0"
-    },
-    {
-      "code": 6006,
-      "name": "InvaildTickIndex",
-      "msg": "Tick out of range"
-    },
-    {
-      "code": 6007,
-      "name": "TickInvaildOrder",
-      "msg": "The lower tick must be below the upper tick"
-    },
-    {
-      "code": 6008,
-      "name": "TickLowerOverflow",
-      "msg": "The tick must be greater, or equal to the minimum tick(-443636)"
-    },
-    {
-      "code": 6009,
-      "name": "TickUpperOverflow",
-      "msg": "The tick must be lesser than, or equal to the maximum tick(443636)"
-    },
-    {
-      "code": 6010,
-      "name": "TickAndSpacingNotMatch",
-      "msg": "tick % tick_spacing must be zero"
-    },
-    {
-      "code": 6011,
-      "name": "InvalidTickArray",
-      "msg": "Invaild tick array account"
-    },
-    {
-      "code": 6012,
-      "name": "InvalidTickArrayBoundary",
-      "msg": "Invaild tick array boundary"
-    },
-    {
-      "code": 6013,
-      "name": "SqrtPriceLimitOverflow",
-      "msg": "Square root price limit overflow"
-    },
-    {
-      "code": 6014,
-      "name": "SqrtPriceX64",
-      "msg": "sqrt_price_x64 out of range"
-    },
-    {
-      "code": 6015,
-      "name": "LiquiditySubValueErr",
-      "msg": "Liquidity sub delta L must be smaller than before"
-    },
-    {
-      "code": 6016,
-      "name": "LiquidityAddValueErr",
-      "msg": "Liquidity add delta L must be greater, or equal to before"
-    },
-    {
-      "code": 6017,
-      "name": "InvaildLiquidity",
-      "msg": "Invaild liquidity when update position"
-    },
-    {
-      "code": 6018,
-      "name": "ForbidBothZeroForSupplyLiquidity",
-      "msg": "Both token amount must not be zero while supply liquidity"
-    },
-    {
-      "code": 6019,
-      "name": "LiquidityInsufficient",
-      "msg": "Liquidity insufficient"
-    },
-    {
-      "code": 6020,
-      "name": "TransactionTooOld",
-      "msg": "Transaction too old"
-    },
-    {
-      "code": 6021,
-      "name": "PriceSlippageCheck",
-      "msg": "Price slippage check"
-    },
-    {
-      "code": 6022,
-      "name": "TooLittleOutputReceived",
-      "msg": "Too little output received"
-    },
-    {
-      "code": 6023,
-      "name": "TooMuchInputPaid",
-      "msg": "Too much input paid"
-    },
-    {
-      "code": 6024,
-      "name": "ZeroAmountSpecified",
-      "msg": "Swap special amount can not be zero"
-    },
-    {
-      "code": 6025,
-      "name": "InvalidInputPoolVault",
-      "msg": "Input pool vault is invalid"
-    },
-    {
-      "code": 6026,
-      "name": "TooSmallInputOrOutputAmount",
-      "msg": "Swap input or output amount is too small"
-    },
-    {
-      "code": 6027,
-      "name": "NotEnoughTickArrayAccount",
-      "msg": "Not enought tick array account"
-    },
-    {
-      "code": 6028,
-      "name": "InvalidFirstTickArrayAccount",
-      "msg": "Invaild first tick array account"
-    },
-    {
-      "code": 6029,
-      "name": "InvalidRewardIndex",
-      "msg": "Invalid reward index"
-    },
-    {
-      "code": 6030,
-      "name": "FullRewardInfo",
-      "msg": "The init reward token reach to the max"
-    },
-    {
-      "code": 6031,
-      "name": "RewardTokenAlreadyInUse",
-      "msg": "The init reward token already in use"
-    },
-    {
-      "code": 6032,
-      "name": "ExceptPoolVaultMint",
-      "msg": "The reward tokens must contain one of pool vault mint except the last reward"
-    },
-    {
-      "code": 6033,
-      "name": "InvalidRewardInitParam",
-      "msg": "Invalid reward init param"
-    },
-    {
-      "code": 6034,
-      "name": "InvalidRewardDesiredAmount",
-      "msg": "Invalid collect reward desired amount"
-    },
-    {
-      "code": 6035,
-      "name": "InvalidRewardInputAccountNumber",
-      "msg": "Invalid collect reward input account number"
-    },
-    {
-      "code": 6036,
-      "name": "InvalidRewardPeriod",
-      "msg": "Invalid reward period"
-    },
-    {
-      "code": 6037,
-      "name": "NotApproveUpdateRewardEmissiones",
-      "msg": "Modification of emissiones is allowed within 72 hours from the end of the previous cycle"
-    },
-    {
-      "code": 6038,
-      "name": "UnInitializedRewardInfo",
-      "msg": "uninitialized reward info"
-    },
-    {
-      "code": 6039,
-      "name": "NotSupportMint",
-      "msg": "Not support token_2022 mint extension"
-    },
-    {
-      "code": 6040,
-      "name": "MissingTickArrayBitmapExtensionAccount",
-      "msg": "Missing tickarray bitmap extension account"
-    },
-    {
-      "code": 6041,
-      "name": "InsufficientLiquidityForDirection",
-      "msg": "Insufficient liquidity for this direction"
-    },
-    {
-      "code": 6042,
-      "name": "MaxTokenOverflow",
-      "msg": "Max token overflow"
-    },
-    {
-      "code": 6043,
-      "name": "CalculateOverflow",
-      "msg": "calculate overflow"
     }
   ]
 }

--- a/idl/raydium_cpmm.json
+++ b/idl/raydium_cpmm.json
@@ -2762,6 +2762,13 @@
             }
           },
           {
+            "name": "last_update_timestamp",
+            "docs": [
+              "the last update timestamp"
+            ],
+            "type": "u64"
+          },
+          {
             "name": "padding",
             "docs": [
               "padding for feature update"
@@ -2769,7 +2776,7 @@
             "type": {
               "array": [
                 "u64",
-                4
+                3
               ]
             }
           }

--- a/idl/raydium_launchpad.json
+++ b/idl/raydium_launchpad.json
@@ -1109,6 +1109,79 @@
       "args": []
     },
     {
+      "name": "close_platform_global_access",
+      "docs": [
+        "Close a platform's permission to use a global config."
+      ],
+      "discriminator": [
+        123,
+        180,
+        184,
+        129,
+        111,
+        185,
+        187,
+        59
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "signer": true,
+          "address": "GThUX1Atko4tqhN2NaiTazWSeFWMuiUvfFnyJyUghFMJ"
+        },
+        {
+          "name": "global_config"
+        },
+        {
+          "name": "platform_config"
+        },
+        {
+          "name": "platform_global_access",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  108,
+                  97,
+                  116,
+                  102,
+                  111,
+                  114,
+                  109,
+                  95,
+                  103,
+                  108,
+                  111,
+                  98,
+                  97,
+                  108,
+                  95,
+                  97,
+                  99,
+                  99,
+                  101,
+                  115,
+                  115
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "platform_config"
+              },
+              {
+                "kind": "account",
+                "path": "global_config"
+              }
+            ]
+          }
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "collect_fee",
       "docs": [
         "Collects accumulated fees from the pool",
@@ -1538,6 +1611,84 @@
           }
         }
       ]
+    },
+    {
+      "name": "create_platform_global_access",
+      "docs": [
+        "Create a platform permission to use a global config when authorization is enabled."
+      ],
+      "discriminator": [
+        162,
+        91,
+        146,
+        199,
+        93,
+        133,
+        234,
+        237
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "writable": true,
+          "signer": true,
+          "address": "GThUX1Atko4tqhN2NaiTazWSeFWMuiUvfFnyJyUghFMJ"
+        },
+        {
+          "name": "global_config"
+        },
+        {
+          "name": "platform_config"
+        },
+        {
+          "name": "platform_global_access",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  108,
+                  97,
+                  116,
+                  102,
+                  111,
+                  114,
+                  109,
+                  95,
+                  103,
+                  108,
+                  111,
+                  98,
+                  97,
+                  108,
+                  95,
+                  97,
+                  99,
+                  99,
+                  101,
+                  115,
+                  115
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "platform_config"
+              },
+              {
+                "kind": "account",
+                "path": "global_config"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
     },
     {
       "name": "create_platform_vesting_account",
@@ -4116,6 +4267,7 @@
         "* `param` - Parameter to update:",
         "- 0: Update trade_fee_rate",
         "- 1: Update fee owner",
+        "- 12: Toggle whether explicit platform authorization is required",
         "* `value` - New value for the selected parameter",
         ""
       ],
@@ -4355,6 +4507,19 @@
       ]
     },
     {
+      "name": "PlatformGlobalAccess",
+      "discriminator": [
+        174,
+        147,
+        132,
+        240,
+        137,
+        219,
+        243,
+        16
+      ]
+    },
+    {
       "name": "PoolState",
       "discriminator": [
         247,
@@ -4545,6 +4710,16 @@
       "code": 6021,
       "name": "InvalidTotalLockedAmount",
       "msg": "Total locked amount must great or equal to the platform vesting share amount"
+    },
+    {
+      "code": 6022,
+      "name": "PlatformGlobalAccessDenied",
+      "msg": "Platform is not authorized to use this global config"
+    },
+    {
+      "code": 6023,
+      "name": "InvalidPlatformGlobalAccess",
+      "msg": "Invalid platform-global access account"
     }
   ],
   "types": [
@@ -4897,6 +5072,25 @@
             "type": "pubkey"
           },
           {
+            "name": "requires_platform_auth",
+            "docs": [
+              "Whether a platform must be explicitly authorized before using this global config"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding_alignment",
+            "docs": [
+              "padding alignment"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                7
+              ]
+            }
+          },
+          {
             "name": "padding",
             "docs": [
               "padding for future updates"
@@ -4904,7 +5098,7 @@
             "type": {
               "array": [
                 "u64",
-                16
+                15
               ]
             }
           }
@@ -5336,6 +5530,38 @@
               "array": [
                 "u64",
                 50
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PlatformGlobalAccess",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "global_config",
+            "type": "pubkey"
+          },
+          {
+            "name": "platform_config",
+            "type": "pubkey"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding for future updates"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                8
               ]
             }
           }


### PR DESCRIPTION
## Summary
- update sol-parser-sdk from 0.6.1 to the published crates.io 0.6.2 release
- sync current official Meteora DLMM, DAMM V2, Dynamic AMM, and Dynamic Bonding Curve IDLs
- sync current official Raydium CLMM, CPMM, and Launchpad IDLs
- sync the current Orca Whirlpool artifact
- preserve compatibility-only AMM V4 references because Raydium AMM V4 is not an Anchor program

## Runtime impact
sol-parser-sdk 0.6.2 includes the current Meteora DLMM Anchor event-CPI parser, current Raydium and Orca layouts, and occurrence-aware CPI/log deduplication. The streamer now consumes that implementation directly from crates.io without a path or Git override.

## Validation
- sol-parser-sdk 0.6.2 published and independently downloaded from crates.io
- cargo tree resolves sol-parser-sdk 0.6.2 from the crates.io registry
- cargo test --locked: 60 passed with the default sdk-parse-borsh backend
- cargo test --locked --no-default-features --features sdk-parse-zero-copy: 60 passed
- every IDL JSON file parses with jq
- canonical IDL hashes match protocol-maintained upstream files
- git diff --check

Cargo.lock remains untracked according to the repository's existing library-crate policy.