### PR TITLE
Update sol-parser-sdk to 0.6.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ sdk-perf-stats = ["sol-parser-sdk/perf-stats"]
 sdk-ultra-perf = ["sol-parser-sdk/ultra-perf"]
 
 [dependencies]
-sol-parser-sdk = { version = "0.6.3", default-features = false }
+sol-parser-sdk = { version = "0.6.4", default-features = false }
 solana-sdk = "3.0.0"
 solana-client = "3.1.12"
 solana-transaction-status = "3.1.12"

--- a/src/streaming/event_parser/core/merger_event.rs
+++ b/src/streaming/event_parser/core/merger_event.rs
@@ -811,6 +811,12 @@ pub fn merge(instruction_event: &mut DexEvent, cpi_log_event: DexEvent) {
         // Meteora DLMM
         DexEvent::MeteoraDlmmSwapEvent(e) => match cpi_log_event {
             DexEvent::MeteoraDlmmSwapEvent(cpie) => {
+                if cpie.token_x_mint != Pubkey::default() {
+                    e.token_x_mint = cpie.token_x_mint;
+                }
+                if cpie.token_y_mint != Pubkey::default() {
+                    e.token_y_mint = cpie.token_y_mint;
+                }
                 if cpie.pool != Pubkey::default() {
                     e.pool = cpie.pool;
                 }

--- a/src/streaming/event_parser/protocols/sol_parser_forward/events.rs
+++ b/src/streaming/event_parser/protocols/sol_parser_forward/events.rs
@@ -310,6 +310,10 @@ pub struct MeteoraPoolsSetPoolFeesEvent {
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MeteoraDlmmSwapEvent {
     pub metadata: EventMetadata,
+    #[serde(default)]
+    pub token_x_mint: Pubkey,
+    #[serde(default)]
+    pub token_y_mint: Pubkey,
     pub pool: Pubkey,
     pub from: Pubkey,
     pub start_bin_id: i32,

--- a/src/streaming/parser_sdk_bridge/forward_pb.rs
+++ b/src/streaming/parser_sdk_bridge/forward_pb.rs
@@ -360,6 +360,8 @@ pub(crate) fn meteora_dlmm_swap_from_pb(
 ) -> MeteoraDlmmSwapEvent {
     MeteoraDlmmSwapEvent {
         metadata: meta,
+        token_x_mint: e.token_x_mint,
+        token_y_mint: e.token_y_mint,
         pool: e.pool,
         from: e.from,
         start_bin_id: e.start_bin_id,

--- a/src/streaming/parser_sdk_bridge/mod.rs
+++ b/src/streaming/parser_sdk_bridge/mod.rs
@@ -446,8 +446,12 @@ mod tests {
     fn converts_meteora_dlmm_swap_preserving_amounts() {
         let pool = Pubkey::new_unique();
         let from = Pubkey::new_unique();
+        let token_x_mint = Pubkey::new_unique();
+        let token_y_mint = Pubkey::new_unique();
         let pb = PbDlmmSwap {
             metadata: EventMetadata::default(),
+            token_x_mint,
+            token_y_mint,
             pool,
             from,
             start_bin_id: -5,
@@ -463,6 +467,8 @@ mod tests {
         let ev = convert_parser_event(PbDexEvent::MeteoraDlmmSwap(pb), None, 0).expect("convert");
         match ev {
             DexEvent::MeteoraDlmmSwapEvent(e) => {
+                assert_eq!(e.token_x_mint, token_x_mint);
+                assert_eq!(e.token_y_mint, token_y_mint);
                 assert_eq!(e.pool, pool);
                 assert_eq!(e.from, from);
                 assert_eq!(e.start_bin_id, -5);

--- a/tests/current_mainnet_transactions.rs
+++ b/tests/current_mainnet_transactions.rs
@@ -28,6 +28,8 @@ fn current_meteora_dlmm_swap_passes_exact_filter() {
     }
     const SIGNATURE: &str =
         "eEWaGsbRPoiD36Xf3epzSMmdtXX36va76b13YfsDV3ncsxQHBTjC68zZ8mbzFXTNWy3n3qKUAHjgHBconX4Gu1i";
+    const TOKEN_X_MINT: &str = "4sWNB8zGWHkh6UnmwiEtzNxL4XrN7uK9tosbESbJFfVs";
+    const TOKEN_Y_MINT: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
     let signature = Signature::from_str(SIGNATURE).expect("valid fixture signature");
     let filter = EventTypeFilter::include_only([EventType::MeteoraDlmmSwap]);
     let events = fetch_rpc_transaction_as_streamer_events(
@@ -46,6 +48,8 @@ fn current_meteora_dlmm_swap_passes_exact_filter() {
     };
     assert_eq!(swap.metadata.signature, signature);
     assert_eq!(swap.metadata.slot, 438_873_646);
+    assert_eq!(swap.token_x_mint.to_string(), TOKEN_X_MINT);
+    assert_eq!(swap.token_y_mint.to_string(), TOKEN_Y_MINT);
     assert_eq!(swap.amount_in, 2_738_183_783);
     assert_eq!(swap.amount_out, 81_555_062);
     assert_eq!(swap.fee, 18_486_656);


### PR DESCRIPTION
## Summary
- update `sol-parser-sdk` from 0.6.3 to 0.6.4
- preserve Meteora DLMM `token_x_mint` and `token_y_mint` through the streamer event bridge and merge path
- extend the reusable 2026-08-13 mainnet fixture with exact mint assertions

## Verification
- `cargo test --locked`
- `cargo test --locked --no-default-features --features sdk-parse-zero-copy`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `RUN_MAINNET_TESTS=1 cargo test --locked --test current_mainnet_transactions current_meteora_dlmm_swap_passes_exact_filter -- --nocapture`
- `RUN_MAINNET_TESTS=1 cargo test --locked --no-default-features --features sdk-parse-zero-copy --test current_mainnet_transactions current_meteora_dlmm_swap_passes_exact_filter -- --nocapture`